### PR TITLE
Handle reverse proxy headers

### DIFF
--- a/source/Octopus.Server.Extensibility/HostServices/Web/DirectoryPathResult.cs
+++ b/source/Octopus.Server.Extensibility/HostServices/Web/DirectoryPathResult.cs
@@ -1,0 +1,27 @@
+﻿namespace Octopus.Server.Extensibility.HostServices.Web
+{
+    public class DirectoryPathResult
+    {
+        private DirectoryPathResult(bool isValid, string path, string invalidReason)
+        {
+            IsValid = isValid;
+            Path = path;
+            InvalidReason = invalidReason;
+        }
+
+        public bool IsValid { get; private set; }
+        public string Path { get; private set; }
+
+        public string InvalidReason { get; private set; }
+
+        public static DirectoryPathResult Success(string directoryPath)
+        {
+            return new DirectoryPathResult(true, directoryPath, null);
+        }
+
+        public static DirectoryPathResult Invalid(string reason)
+        {
+            return new DirectoryPathResult(false, null, reason);
+        }
+    }
+}

--- a/source/Octopus.Server.Extensibility/HostServices/Web/NancyRequestExtensions.cs
+++ b/source/Octopus.Server.Extensibility/HostServices/Web/NancyRequestExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Nancy;
 
 namespace Octopus.Server.Extensibility.HostServices.Web
@@ -6,11 +7,16 @@ namespace Octopus.Server.Extensibility.HostServices.Web
     public static class NancyRequestExtensions
     {
         /// <summary>
-        /// Builds the path to the virtual directory for the given Request.
+        /// Builds the path to the virtual directory for the given Request.  This is required in scenarios where the server 
+        /// needs to understand the absolute path it was called on, from the browser's perspecive.  This is essential to
+        /// making things like the OpenID Connect login process work, because we have to provide them a redirectUrl that will
+        /// get them back to our API using the same protocol and host that the original call was made on (remembering that there
+        /// could be multiple listening prefixes at play and we could also be behind a reverse proxy).
         /// </summary>
         /// <param name="request">The request.</param>
-        /// <returns>The full virtual directory path.</returns>
-        public static string DirectoryPath(this Request request)
+        /// <returns>A result representing full virtual directory path, if it could be determined; otherwise a result explaining 
+        /// why it couldn't be determined.</returns>
+        public static DirectoryPathResult DirectoryPath(this Request request)
         {
             var urlSiteBase = request.Url.SiteBase;
 
@@ -19,10 +25,13 @@ namespace Octopus.Server.Extensibility.HostServices.Web
             {
                 var forwardedProto = request.Headers["X-Forwarded-Proto"].FirstOrDefault();
 
+                if (forwardedProto == null)
+                    return DirectoryPathResult.Invalid("X-Forwarded-Host' was supplied, but 'X-Forwarded-Proto' header was not. Please configure your proxy to pass this header through.");
+
                 urlSiteBase = $"{forwardedProto}://{forwardedHost}";
             }
 
-            return urlSiteBase + request.Url.BasePath;
+            return DirectoryPathResult.Success(urlSiteBase + request.Url.BasePath);
         }
     }
 }

--- a/source/Octopus.Server.Extensibility/HostServices/Web/NancyRequestExtensions.cs
+++ b/source/Octopus.Server.Extensibility/HostServices/Web/NancyRequestExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Nancy;
+﻿using System.Linq;
+using Nancy;
 
 namespace Octopus.Server.Extensibility.HostServices.Web
 {
@@ -11,7 +12,17 @@ namespace Octopus.Server.Extensibility.HostServices.Web
         /// <returns>The full virtual directory path.</returns>
         public static string DirectoryPath(this Request request)
         {
-            return request.Url.SiteBase + request.Url.BasePath;
+            var urlSiteBase = request.Url.SiteBase;
+
+            var forwardedHost = request.Headers["X-Forwarded-Host"].FirstOrDefault();
+            if (forwardedHost != null)
+            {
+                var forwardedProto = request.Headers["X-Forwarded-Proto"].FirstOrDefault();
+
+                urlSiteBase = $"{forwardedProto}://{forwardedHost}";
+            }
+
+            return urlSiteBase + request.Url.BasePath;
         }
     }
 }

--- a/source/Octopus.Server.Extensibility/Octopus.Server.Extensibility.csproj
+++ b/source/Octopus.Server.Extensibility/Octopus.Server.Extensibility.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Extensions\Infrastructure\Configuration\IHandleLegacyWebAuthenticationModeConfigurationCommand.cs" />
     <Compile Include="Extensions\Infrastructure\Web\Content\IContributesCSS.cs" />
     <Compile Include="Extensions\Infrastructure\Web\Content\IContributesJavascript.cs" />
+    <Compile Include="HostServices\Web\DirectoryPathResult.cs" />
     <Compile Include="HostServices\Web\IUserMapper.cs" />
     <Compile Include="Extensions\Infrastructure\Web\Content\IContributesStaticContentFolders.cs" />
     <Compile Include="Extensions\Infrastructure\Web\Content\StaticContentEmbeddedResourcesFolder.cs" />


### PR DESCRIPTION
If the request contains X-Forwarded-* headers then use those to build the DirectoryPath