### PR TITLE
Support typed config values

### DIFF
--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationSettings.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationSettings.cs
@@ -33,7 +33,7 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
             ConfigurationDocumentStore.SetConfiguration(config);
         }
 
-        public abstract IEnumerable<ConfigurationValue> GetConfigurationValues();
+        public abstract IEnumerable<IConfigurationValue> GetConfigurationValues();
 
         public abstract void BuildMappings(IResourceMappingsBuilder builder);
     }
@@ -49,7 +49,7 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 
         public Type MetadataResourceType => typeof(TResource);
 
-        public abstract IEnumerable<ConfigurationValue> GetConfigurationValues();
+        public abstract IEnumerable<IConfigurationValue> GetConfigurationValues();
 
         public abstract object GetConfigurationResource();
     }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationValue.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationValue.cs
@@ -2,6 +2,14 @@
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
+    public interface IConfigurationValue
+    {
+        string Key { get; set; }
+        object Value { get; }
+        bool ShowInPortalSummary { get; set; }
+        string Description { get; set; }
+        bool IsSensitive { get; set; }
+    }
 
     public class ConfigurationValue<T> : IConfigurationValue
     {
@@ -24,14 +32,5 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
         public bool ShowInPortalSummary { get; set; }
         public string Description { get; set; }
         public bool IsSensitive { get; set; }
-    }
-
-    public interface IConfigurationValue
-    {
-        string Key { get; set; }
-        object Value { get; }
-        bool ShowInPortalSummary { get; set; }
-        string Description { get; set; }
-        bool IsSensitive { get; set; }
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationValue.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationValue.cs
@@ -1,24 +1,37 @@
-﻿namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+﻿using Newtonsoft.Json;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
-    public class ConfigurationValue
+
+    public class ConfigurationValue<T> : IConfigurationValue
     {
         protected ConfigurationValue()
         {}
 
-        public ConfigurationValue(string key, string value, bool showInPortalSummary, string description = "", bool isSensitive = false)
+        public ConfigurationValue(string key, T value, bool showInPortalSummary, string description = "", bool isSensitive = false)
         {
             Key = key;
-            Value = value;
+            TypedValue = value;
             ShowInPortalSummary = showInPortalSummary;
             Description = description;
             IsSensitive = isSensitive;
         }
 
         public string Key { get; set; }
-        public string Value { get; set; }
+        public object Value => TypedValue;
+        [JsonIgnore]
+        public T TypedValue { get; set; }
         public bool ShowInPortalSummary { get; set; }
-
         public string Description { get; set; }
         public bool IsSensitive { get; set; }
+    }
+
+    public interface IConfigurationValue
+    {
+        string Key { get; set; }
+        object Value { get; }
+        bool ShowInPortalSummary { get; set; }
+        string Description { get; set; }
+        bool IsSensitive { get; set; }
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasAggregatedConfigurationSettings.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasAggregatedConfigurationSettings.cs
@@ -1,5 +1,6 @@
 ﻿namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
+    //note: we are hoping to get rid of this interface
     public interface IHasAggregatedConfigurationSettings : IHasConfigurationSettingsResource
     {
         object GetConfigurationResource();

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsResource.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsResource.cs
@@ -13,6 +13,6 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 
         Type MetadataResourceType { get; }
 
-        IEnumerable<ConfigurationValue> GetConfigurationValues();
+        IEnumerable<IConfigurationValue> GetConfigurationValues();
     }
 }


### PR DESCRIPTION
Allow config values to use their base type (int/bool/string), rather than casting everything to a string