### PR TITLE
The id comparisons have to be case insensitive, especially for Work I…

### DIFF
--- a/source/Node.Extensibility.Tests/WorkItems/CommitFixture.cs
+++ b/source/Node.Extensibility.Tests/WorkItems/CommitFixture.cs
@@ -9,7 +9,7 @@ namespace Node.Extensibility.Tests.WorkItems
     public class CommitFixture
     {
         [Test]
-        public void DistinctWorkItemsBehavesCorrectly()
+        public void DistinctCommitsBehavesCorrectly()
         {
             var listWithDupes = new List<Commit>
             {
@@ -24,7 +24,7 @@ namespace Node.Extensibility.Tests.WorkItems
         }
 
         [Test]
-        public void DistinctWorkItemsBehavesCorrectlyWithDifferentCasing()
+        public void DistinctCommitsBehavesCorrectlyWithDifferentCasing()
         {
             var listWithDupes = new List<Commit>
             {

--- a/source/Node.Extensibility.Tests/WorkItems/WorkItemLinkFixture.cs
+++ b/source/Node.Extensibility.Tests/WorkItems/WorkItemLinkFixture.cs
@@ -1,21 +1,21 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using Octopus.Server.Extensibility.HostServices.Model.IssueTrackers;
+using Octopus.Server.Extensibility.Resources.IssueTrackers;
 
 namespace Node.Extensibility.Tests.WorkItems
 {
     [TestFixture]
-    public class CommitFixture
+    public class WorkItemLinkFixture
     {
         [Test]
         public void DistinctWorkItemsBehavesCorrectly()
         {
-            var listWithDupes = new List<Commit>
+            var listWithDupes = new List<WorkItemLink>
             {
-                new Commit { Id = "test1" },
-                new Commit { Id = "test2" },
-                new Commit { Id = "test1" },
+                new WorkItemLink { Id = "test1" },
+                new WorkItemLink { Id = "test2" },
+                new WorkItemLink { Id = "test1" },
             };
 
             var distinctWorkItems = listWithDupes.Distinct();
@@ -26,11 +26,11 @@ namespace Node.Extensibility.Tests.WorkItems
         [Test]
         public void DistinctWorkItemsBehavesCorrectlyWithDifferentCasing()
         {
-            var listWithDupes = new List<Commit>
+            var listWithDupes = new List<WorkItemLink>
             {
-                new Commit { Id = "test1" },
-                new Commit { Id = "test2" },
-                new Commit { Id = "Test1" },
+                new WorkItemLink { Id = "test1" },
+                new WorkItemLink { Id = "test2" },
+                new WorkItemLink { Id = "Test1" },
             };
 
             var distinctWorkItems = listWithDupes.Distinct();

--- a/source/Server.Extensibility/HostServices/Model/IssueTrackers/Commit.cs
+++ b/source/Server.Extensibility/HostServices/Model/IssueTrackers/Commit.cs
@@ -17,14 +17,14 @@ namespace Octopus.Server.Extensibility.HostServices.Model.IssueTrackers
 
         public override int GetHashCode()
         {
-            return (Id != null ? Id.GetHashCode() : 0);
+            return (Id != null ? Id.ToUpperInvariant().GetHashCode() : 0);
         }
 
         public bool Equals(Commit other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Id, other.Id);
+            return string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/source/Server.Extensibility/Resources/IssueTrackers/WorkItemLink.cs
+++ b/source/Server.Extensibility/Resources/IssueTrackers/WorkItemLink.cs
@@ -12,7 +12,7 @@ namespace Octopus.Server.Extensibility.Resources.IssueTrackers
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Id, other.Id);
+            return string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object obj)
@@ -25,7 +25,7 @@ namespace Octopus.Server.Extensibility.Resources.IssueTrackers
 
         public override int GetHashCode()
         {
-            return (Id != null ? Id.GetHashCode() : 0);
+            return (Id != null ? Id.ToUpperInvariant().GetHashCode() : 0);
         }
     }
 }


### PR DESCRIPTION
…tem references because they are manually entered in the comments

Relates to OctopusDeploy/Issues#5530