### PR TITLE
Serialize configuration enum values as strings

### DIFF
--- a/source/Node.Extensibility.Tests/Extensions/Infrastructure/Configuration/ConfigurationValueFixture.cs
+++ b/source/Node.Extensibility.Tests/Extensions/Infrastructure/Configuration/ConfigurationValueFixture.cs
@@ -9,7 +9,7 @@ namespace Node.Extensibility.Tests.Extensions.Infrastructure.Configuration
     public class ConfigurationValueFixture
     {
         [Test]
-        public void SerializeObject_WithEnumValue_AsString()
+        public void EnumValuesShouldBeSerializedAsStrings()
         {
             var toSerialize = new ConfigurationValue<SomeEnum>("Some.Key", SomeEnum.SomeEnumValue, true, "Some description");
 

--- a/source/Node.Extensibility.Tests/Extensions/Infrastructure/Configuration/ConfigurationValueFixture.cs
+++ b/source/Node.Extensibility.Tests/Extensions/Infrastructure/Configuration/ConfigurationValueFixture.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
+
+namespace Node.Extensibility.Tests.Extensions.Infrastructure.Configuration
+{
+    [TestFixture]
+    public class ConfigurationValueFixture
+    {
+        [Test]
+        public void SerializeObject_WithEnumValue_AsString()
+        {
+            var toSerialize = new ConfigurationValue<SomeEnum>("Some.Key", SomeEnum.SomeEnumValue, true, "Some description");
+
+            var serialized = JsonConvert.SerializeObject(toSerialize);
+
+            serialized.Should().Be("{\"Key\":\"Some.Key\",\"Value\":\"SomeEnumValue\",\"ShowInPortalSummary\":true,\"Description\":\"Some description\",\"IsSensitive\":false}");
+        }
+
+        private enum SomeEnum
+        {
+            SomeEnumValue
+        }
+    }
+}

--- a/source/Node.Extensibility.Tests/Node.Extensibility.Tests.csproj
+++ b/source/Node.Extensibility.Tests/Node.Extensibility.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationValue.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationValue.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
@@ -26,9 +27,13 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
         }
 
         public string Key { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
         public object Value => TypedValue;
+
         [JsonIgnore]
         public T TypedValue { get; set; }
+
         public bool ShowInPortalSummary { get; set; }
         public string Description { get; set; }
         public bool IsSensitive { get; set; }


### PR DESCRIPTION
- Currently, extension configuration settings that use enums have to `ToString` explicitly in order to serialize their values as strings
- This change introduces a `StringEnumConverter` attribute that allows the conversion to be done implicitly, instead
- Relates to https://github.com/OctopusDeploy/OctopusDeploy/pull/3799/ (in that PR, we need to avoid a regression in `ShowConfigurationCommand`, which previously used `ToString` explicitly to serialize the `NotificationMode` setting)