### PR TITLE
Update metadata generator to provide property applicability

### DIFF
--- a/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.MetadataShouldHandleDependentProperties.approved.txt
+++ b/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.MetadataShouldHandleDependentProperties.approved.txt
@@ -1,0 +1,42 @@
+{
+  "Types": [
+    {
+      "Name": "DependentPropertiesResource",
+      "Properties": [
+        {
+          "Name": "PropertyA",
+          "Type": "string",
+          "DisplayInfo": {
+            "Required": false,
+            "ReadOnly": true,
+            "Label": "PropertyA",
+            "Description": null,
+            "Options": null,
+            "ListApi": null,
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
+          }
+        },
+        {
+          "Name": "PropertyB",
+          "Type": "string",
+          "DisplayInfo": {
+            "Required": false,
+            "ReadOnly": true,
+            "Label": "PropertyB",
+            "Description": null,
+            "Options": null,
+            "ListApi": null,
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": {
+              "Mode": "ApplicableIfSpecificValue",
+              "DependsOnPropertyName": "PropertyA",
+              "DependsOnPropertyValue": "Foo"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "Description": null
+}

--- a/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.MetadataShouldHandleNavigationalProperties.approved.txt
+++ b/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.MetadataShouldHandleNavigationalProperties.approved.txt
@@ -13,7 +13,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -26,7 +27,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         }
       ]
@@ -44,7 +46,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -57,7 +60,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         }
       ]

--- a/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.MetadataShouldHandleSelfReferences.approved.txt
+++ b/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.MetadataShouldHandleSelfReferences.approved.txt
@@ -13,7 +13,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -26,7 +27,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -39,7 +41,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         }
       ]

--- a/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.SettingsMetadataShouldBeCorrect.approved.txt
+++ b/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.SettingsMetadataShouldBeCorrect.approved.txt
@@ -13,7 +13,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -26,7 +27,8 @@
             "Description": "This 2nd-level resource has been duplicated",
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -39,7 +41,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -52,7 +55,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -65,7 +69,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -86,7 +91,8 @@
               }
             },
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -99,7 +105,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -112,7 +119,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -125,7 +133,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -138,7 +147,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -151,7 +161,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         }
       ]
@@ -169,7 +180,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -182,7 +194,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -195,7 +208,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -208,7 +222,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         },
         {
@@ -221,7 +236,8 @@
             "Description": null,
             "Options": null,
             "ListApi": null,
-            "ShowCopyToClipboard": false
+            "ShowCopyToClipboard": false,
+            "PropertyApplicability": null
           }
         }
       ]

--- a/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.cs
+++ b/source/Node.Extensibility.Tests/Metadata/MetadataGeneratorFixture.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using Assent;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using NUnit.Framework;
 using Octopus.Data.Resources;
 using Octopus.Data.Resources.Attributes;
@@ -59,6 +60,24 @@ namespace Node.Extensibility.Tests.Metadata
             var serializerSettings = new JsonSerializerSettings
             {
                 Formatting = Formatting.Indented,
+            };
+
+            var json = JsonConvert.SerializeObject(metadata, serializerSettings);
+
+            this.Assent(json);
+        }
+
+        [Test]
+        public void MetadataShouldHandleDependentProperties()
+        {
+            IGenerateMetadata generator = new MetadataGenerator();
+
+            var metadata = generator.GetMetadata<DependentPropertiesResource>();
+
+            var serializerSettings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented,
+                Converters = new List<JsonConverter> { new StringEnumConverter() }
             };
 
             var json = JsonConvert.SerializeObject(metadata, serializerSettings);
@@ -166,6 +185,14 @@ namespace Node.Extensibility.Tests.Metadata
             public string[] StringArrayProperty { get; set; }
 
             public int[] IntArrayProperty { get; set; }
+        }
+
+        public class DependentPropertiesResource
+        {
+            public string PropertyA { get; set; }
+            
+            [ApplicableWhenSpecificValue(nameof(PropertyA), "Foo")]
+            public string PropertyB { get; set; }
         }
     }
 }

--- a/source/Server.Extensibility/Metadata/DisplayInfo.cs
+++ b/source/Server.Extensibility/Metadata/DisplayInfo.cs
@@ -15,5 +15,7 @@
         public ListApiMetadata ListApi { get; set; }
         
         public bool ShowCopyToClipboard { get; set; }
+        
+        public PropertyApplicability PropertyApplicability { get; set; }
     }
 }

--- a/source/Server.Extensibility/Metadata/MetadataGenerator.cs
+++ b/source/Server.Extensibility/Metadata/MetadataGenerator.cs
@@ -145,7 +145,18 @@ namespace Octopus.Server.Extensibility.Metadata
                                 ApiEndpoint = listApiAttr.ApiEndpoint,
                             };
                         }
+                    }
 
+                    if (prop.IsDefined(typeof(PropertyApplicabilityAttribute)))
+                    {
+                        var applicableAttr = prop.GetCustomAttribute<PropertyApplicabilityAttribute>();
+                        
+                        propMetadata.DisplayInfo.PropertyApplicability = new PropertyApplicability
+                        {
+                            Mode = applicableAttr.Mode,
+                            DependsOnPropertyName = applicableAttr.PropertyName,
+                            DependsOnPropertyValue = applicableAttr.PropertyValue
+                        };
                     }
 
                     rootType.Properties.Add(propMetadata);

--- a/source/Server.Extensibility/Metadata/MetadataGenerator.cs
+++ b/source/Server.Extensibility/Metadata/MetadataGenerator.cs
@@ -154,8 +154,8 @@ namespace Octopus.Server.Extensibility.Metadata
                         propMetadata.DisplayInfo.PropertyApplicability = new PropertyApplicability
                         {
                             Mode = applicableAttr.Mode,
-                            DependsOnPropertyName = applicableAttr.PropertyName,
-                            DependsOnPropertyValue = applicableAttr.PropertyValue
+                            DependsOnPropertyName = applicableAttr.DependsOnPropertyName,
+                            DependsOnPropertyValue = applicableAttr.DependsOnPropertyValue
                         };
                     }
 

--- a/source/Server.Extensibility/Metadata/PropertyApplicability.cs
+++ b/source/Server.Extensibility/Metadata/PropertyApplicability.cs
@@ -1,0 +1,10 @@
+using Octopus.Data.Resources.Attributes;
+
+namespace Octopus.Server.Extensibility.Metadata
+{
+    public class PropertyApplicability {
+        public PropertyApplicabilityMode Mode { get; set; }
+        public string DependsOnPropertyName { get; set; }
+        public object DependsOnPropertyValue { get; set; }
+    }
+}

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="Octopus.Data" Version="3.2.0" />
+    <PackageReference Include="Octopus.Data" Version="4.0.2-enh-dynamic-prop0002" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
   </ItemGroup>

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="Octopus.Data" Version="4.0.2-enh-dynamic-prop0002" />
+    <PackageReference Include="Octopus.Data" Version="4.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
The metadata can now allow one property to have an attribute that declares it is only applicable when another property has a specific value.

Relates to OctopusDeploy/JiraIssueTracker#6