### PR TITLE
Removing unused property on IDeployment

### DIFF
--- a/source/Server.Extensibility/HostServices/Model/Projects/IDeployment.cs
+++ b/source/Server.Extensibility/HostServices/Model/Projects/IDeployment.cs
@@ -27,8 +27,6 @@ namespace Octopus.Server.Extensibility.HostServices.Model.Projects
         string DeploymentProcessId { get; }
         string ManifestVariableSetId { get; }
 
-        string ProjectGroupId { get; }
-
         string DeployedBy { get; }
 
         string DeployedById { get; }


### PR DESCRIPTION
## Background / motivation
`IDeployment.ProjectGroupId` isn't used very much (if at all) in our server side code - and can cause some issues getting out of sync when projects are moved to a different project group. 

This causes subsequent pain for users of the migration API

## How to review
Quick sanity check here

## Links
[Internal discussion](https://octopusdeploy.slack.com/archives/CDANN5QLT/p1560844430095600)
[Related issue](https://github.com/OctopusDeploy/Issues/issues/5646)
[Related PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/4009)