### PR TITLE
Support failure warnings in IWorkItemLinkMapper.Map()

### DIFF
--- a/source/Server.Extensibility/Extensions/ExtResult.cs
+++ b/source/Server.Extensibility/Extensions/ExtResult.cs
@@ -9,6 +9,14 @@ namespace Octopus.Server.Extensibility.Extensions
         string FailureReason { get; }
     }
 
+    public interface IExtResult<out T> : IExtResult
+    {
+        // Note: be careful about using `IExtResult<T>` as a return type, since it's a reference type that introduces another possibility of a null,
+        // inhibits the implicit casts that make `ExtResult<T>` easier to use, and is only marginally more flexible.
+
+        T Value { get; }
+    }
+
     public struct FailureResult : IExtResult
     {
         public bool Succeeded => false;
@@ -20,7 +28,7 @@ namespace Octopus.Server.Extensibility.Extensions
         }
     }
 
-    public struct ExtResult<T> : IExtResult
+    public struct ExtResult<T> : IExtResult<T>
     {
         public bool Succeeded { get; private set; }
         public string FailureReason { get; private set; }

--- a/source/Server.Extensibility/Extensions/ExtResult.cs
+++ b/source/Server.Extensibility/Extensions/ExtResult.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Server.Extensibility.Extensions
+{
+    public interface IExtResult
+    {
+        bool Succeeded { get; }
+        string FailureReason { get; }
+    }
+
+    public struct FailureResult : IExtResult
+    {
+        public bool Succeeded => false;
+        public string FailureReason { get; }
+
+        public FailureResult(string failureReason)
+        {
+            FailureReason = failureReason;
+        }
+    }
+
+    public struct ExtResult<T> : IExtResult
+    {
+        public bool Succeeded { get; private set; }
+        public string FailureReason { get; private set; }
+        public T Value { get; private set; }
+
+        public static ExtResult<T> Success(T value)
+        {
+            return new ExtResult<T> {Succeeded = true, Value = value};
+        }
+
+        public static ExtResult<T> Failure(string reason, T partialValue = default(T))
+        {
+            return new ExtResult<T> {Succeeded = false, FailureReason = reason, Value = partialValue};
+        }
+
+        public static implicit operator ExtResult<T>(T value)
+        {
+            return Success(value);
+        }
+
+        public static implicit operator ExtResult<T>(FailureResult result)
+        {
+            return new ExtResult<T> {Succeeded = result.Succeeded, FailureReason = result.FailureReason};
+        }
+    }
+
+    public static class ExtResult
+    {
+        public static ExtResult<T> Success<T>(T value) => ExtResult<T>.Success(value);
+
+        public static FailureResult Failure(string reason) => new FailureResult(reason);
+
+        public static FailureResult Failure(IExtResult result) => new FailureResult(result.FailureReason);
+
+        public static ExtResult<T> Failure<T>(string reason, T partialValue)
+            => ExtResult<T>.Failure(reason, partialValue);
+
+        public static ExtResult<T> Conditional<T>(T value, IEnumerable<IExtResult> dependencies)
+        {
+            var anyFailure = dependencies.FirstOrDefault(d => !d.Succeeded);
+            return anyFailure == null
+                ? value
+                : Failure(anyFailure.FailureReason, value);
+        }
+
+        public static ExtResult<T> Conditional<T, TDep>(T value, IEnumerable<ExtResult<TDep>> dependencies)
+            => Conditional(value, dependencies.Cast<IExtResult>());
+
+        public static ExtResult<T> Conditional<T>(T value, params IExtResult[] dependencies)
+            => Conditional(value, (IEnumerable<IExtResult>) dependencies);
+    }
+}

--- a/source/Server.Extensibility/Extensions/SuccessOrErrorResult.cs
+++ b/source/Server.Extensibility/Extensions/SuccessOrErrorResult.cs
@@ -55,7 +55,7 @@ namespace Octopus.Server.Extensibility.Extensions
         }
     }
 
-    public static class ExtResult
+    public static class SuccessOrErrorResult
     {
         public static SuccessOrErrorResult<T> Success<T>(T value) => SuccessOrErrorResult<T>.Success(value);
 

--- a/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
@@ -8,6 +8,6 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         string CommentParser { get; }
         bool IsEnabled { get; }
 
-        ExtResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata);
+        SuccessOrErrorResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata);
     }
 }

--- a/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
@@ -8,6 +8,6 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         string CommentParser { get; }
         bool IsEnabled { get; }
 
-        WorkItemLink[] Map(OctopusPackageMetadata packageMetadata);
+        ExtResult<WorkItemLink[]> Map(OctopusPackageMetadata packageMetadata);
     }
 }


### PR DESCRIPTION
This allows a `FailureReason` to be returned when `Map()` hasn't completely `Succeeded`.

Warning: the issue trackers and server need minor modifications to compile against this. See below for the other PRs referencing this one.

The new `ExtResult<T>` is different from the existing `Octopus.Core.Util.Result<T>` in a few ways:

- It allows getting partial results from `Value` even when the operation hasn't completely `Succeeded`.
- It returns a single `FailureReason` instead of an array. This encourages the extension to summarize its own situation, rather than passing a potentially large and confusing list of problems up to the UI to deal with. Usually the first failure is the one the user should address, before trying to figure out any others.
- `Octopus.Core` isn't currently shipped as a separate package.