### PR TITLE
Improve ReleasePackageVersionBuildInformation equality and WorkItemLink sort

### DIFF
--- a/source/Node.Extensibility.Tests/WorkItems/WorkItemLinkFixture.cs
+++ b/source/Node.Extensibility.Tests/WorkItems/WorkItemLinkFixture.cs
@@ -37,5 +37,31 @@ namespace Node.Extensibility.Tests.WorkItems
 
             Assert.AreEqual(2, distinctWorkItems.Count());
         }
+
+        [Test]
+        public void WorkItemsSortByNumericId()
+        {
+            var workItemLinks = new List<WorkItemLink>
+            {
+                new WorkItemLink {Id = "34"},
+                new WorkItemLink {Id = "5"},
+                new WorkItemLink {Id = "987"}
+            };
+            Assert.AreEqual("5,34,987",
+                string.Join(",", workItemLinks.OrderBy(x => x).Select(x => x.Id)));
+        }
+
+        [Test]
+        public void WorkItemsSortByPrefixedNumber()
+        {
+            var workItemLinks = new List<WorkItemLink>
+            {
+                new WorkItemLink {Id = "JIR7-34"},
+                new WorkItemLink {Id = "JIR7-5"},
+                new WorkItemLink {Id = "JIR7-987"}
+            };
+            Assert.AreEqual("JIR7-5,JIR7-34,JIR7-987",
+                string.Join(",", workItemLinks.OrderBy(x => x).Select(x => x.Id)));
+        }
     }
 }

--- a/source/Server.Extensibility/HostServices/Model/BuildInformation/ReleasePackageVersionBuildInformation.cs
+++ b/source/Server.Extensibility/HostServices/Model/BuildInformation/ReleasePackageVersionBuildInformation.cs
@@ -1,4 +1,5 @@
-﻿using Octopus.Server.Extensibility.Resources.IssueTrackers;
+﻿using System;
+using Octopus.Server.Extensibility.Resources.IssueTrackers;
 
 namespace Octopus.Server.Extensibility.HostServices.Model.BuildInformation
 {
@@ -21,8 +22,31 @@ namespace Octopus.Server.Extensibility.HostServices.Model.BuildInformation
         public string VcsRoot { get; set; }
         public string VcsCommitNumber { get; set; }
         public string VcsCommitUrl { get; set; }
-        
+
         public WorkItemLink[] WorkItems { get; set; }
         public CommitDetails[] Commits { get; set; }
+
+        protected bool Equals(ReleasePackageVersionBuildInformation other)
+        {
+            return string.Equals(PackageId, other.PackageId, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(Version, other.Version, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((ReleasePackageVersionBuildInformation) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((PackageId != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(PackageId) : 0) * 397) ^
+                       (Version != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Version) : 0);
+            }
+        }
     }
 }

--- a/source/Server.Extensibility/Resources/IssueTrackers/WorkItemLink.cs
+++ b/source/Server.Extensibility/Resources/IssueTrackers/WorkItemLink.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Octopus.Server.Extensibility.Resources.IssueTrackers
 {
-    public class WorkItemLink : IEquatable<WorkItemLink>
+    public class WorkItemLink : IEquatable<WorkItemLink>, IComparable<WorkItemLink>
     {
+        static readonly Regex LastNumberRegex = new Regex(@"(\d+)$", RegexOptions.Compiled);
+
         public string Id { get; set; }
         public string LinkUrl { get; set; }
         public string Source { get; set; }
@@ -27,6 +31,17 @@ namespace Octopus.Server.Extensibility.Resources.IssueTrackers
         public override int GetHashCode()
         {
             return (Id != null ? Id.ToUpperInvariant().GetHashCode() : 0);
+        }
+
+        public int CompareTo(WorkItemLink other)
+        {
+            if (ReferenceEquals(this, other)) return 0;
+            if (ReferenceEquals(null, other)) return 1;
+            var thisIdMatch = LastNumberRegex.Match(Id);
+            var otherIdMatch = LastNumberRegex.Match(other.Id);
+            if (thisIdMatch.Success && otherIdMatch.Success)
+                return int.Parse(thisIdMatch.Groups[1].Value) - int.Parse(otherIdMatch.Groups[1].Value);
+            return string.Compare(Id, other.Id, StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
Some equality/sort improvements:

* `WorkItemLink` sorts naturally by Id (in a number-aware way)
* `ReleasePackageVersionBuildInformation` equates by `PackageId` and `Version`, to support .Distinct()