### PR TITLE
Pass a logger and package identifiers to `IWorkItemLinkMapper`

### DIFF
--- a/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
@@ -1,4 +1,5 @@
-﻿using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
+﻿using Octopus.Diagnostics;
+using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.Resources.IssueTrackers;
 
 namespace Octopus.Server.Extensibility.Extensions.WorkItems
@@ -8,6 +9,6 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         string CommentParser { get; }
         bool IsEnabled { get; }
 
-        SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation);
+        SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation, ILogWithContext log);
     }
 }

--- a/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
@@ -1,6 +1,7 @@
 ﻿using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.Resources.IssueTrackers;
+using Octopus.Versioning;
 
 namespace Octopus.Server.Extensibility.Extensions.WorkItems
 {
@@ -9,6 +10,6 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         string CommentParser { get; }
         bool IsEnabled { get; }
 
-        SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation, ILogWithContext log);
+        SuccessOrErrorResult<WorkItemLink[]> Map(string packageId, IVersion version, OctopusBuildInformation buildInformation, ILogWithContext log);
     }
 }

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
     <PackageReference Include="Octopus.Versioning" Version="4.1.3" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="Octopus.Data" Version="4.2.1" />


### PR DESCRIPTION
Passing a specific logger allows us to sink messages into a context-dependent store, ie the Release Log. The package identifiers make it easier to build useful messages.

Part of a solution to OctopusDeploy/Issues#5869.