### PR TITLE
Updates so API hosted by extensions can execute when the extension is disabled

### DIFF
--- a/source/Server.Extensibility/Extensions/Infrastructure/Web/Api/SecuredAdministratorWhenEnabledAsyncActionInvoker.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Web/Api/SecuredAdministratorWhenEnabledAsyncActionInvoker.cs
@@ -5,13 +5,13 @@ using Octopus.Server.Extensibility.HostServices.Authorization;
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api
 {
-    public class SecuredAdministratorAsyncActionInvoker<TAction, TConfigurationStore> : WhenEnabledAsyncActionInvoker<TAction, TConfigurationStore>
+    public class SecuredAdministratorWhenEnabledAsyncActionInvoker<TAction, TConfigurationStore> : WhenEnabledAsyncActionInvoker<TAction, TConfigurationStore>
         where TAction : IAsyncApiAction
         where TConfigurationStore : IExtensionConfigurationStore
     {
         private readonly Lazy<IAuthorizationChecker> authorizationChecker;
 
-        public SecuredAdministratorAsyncActionInvoker(
+        public SecuredAdministratorWhenEnabledAsyncActionInvoker(
             TAction action,
             TConfigurationStore configurationStore, 
             Lazy<IAuthorizationChecker> authorizationChecker) : base(action, configurationStore)

--- a/source/Server.Extensibility/Extensions/Infrastructure/Web/Api/SecuredAsyncActionInvoker.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Web/Api/SecuredAsyncActionInvoker.cs
@@ -1,19 +1,18 @@
-﻿using System;
 using System.Threading.Tasks;
-using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api
 {
-    public class SecuredAsyncActionInvoker<TAction, TConfigurationStore> : WhenEnabledAsyncActionInvoker<TAction, TConfigurationStore>
+    public class SecuredAsyncActionInvoker<TAction>
         where TAction : IAsyncApiAction
-        where TConfigurationStore : IExtensionConfigurationStore
     {
+        protected readonly TAction Action;
 
-        public SecuredAsyncActionInvoker(TAction action, TConfigurationStore configurationStore) : base(action, configurationStore)
+        public SecuredAsyncActionInvoker(TAction action)
         {
+            Action = action;
         }
 
-        public override Task ExecuteAsync(OctoContext context)
+        public virtual Task ExecuteAsync(OctoContext context)
         {
             if (context.User == null)
             {
@@ -21,7 +20,7 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api
                 return Task.FromResult(0);
             }
 
-            return base.ExecuteAsync(context);
+            return Action.ExecuteAsync(context);
         }
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Web/Api/SecuredAsyncWhenEnabledActionInvoker.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Web/Api/SecuredAsyncWhenEnabledActionInvoker.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api
+{
+    public class SecuredAsyncWhenEnabledActionInvoker<TAction, TConfigurationStore> : WhenEnabledAsyncActionInvoker<TAction, TConfigurationStore>
+        where TAction : IAsyncApiAction
+        where TConfigurationStore : IExtensionConfigurationStore
+    {
+
+        public SecuredAsyncWhenEnabledActionInvoker(TAction action, TConfigurationStore configurationStore) : base(action, configurationStore)
+        {
+        }
+
+        public override Task ExecuteAsync(OctoContext context)
+        {
+            if (context.User == null)
+            {
+                context.Response.StatusCode = 401;
+                return Task.FromResult(0);
+            }
+
+            return base.ExecuteAsync(context);
+        }
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Web/Api/SecuredWhenEnabledAsyncActionInvoker.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Web/Api/SecuredWhenEnabledAsyncActionInvoker.cs
@@ -3,12 +3,12 @@ using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api
 {
-    public class SecuredAsyncWhenEnabledActionInvoker<TAction, TConfigurationStore> : WhenEnabledAsyncActionInvoker<TAction, TConfigurationStore>
+    public class SecuredWhenEnabledAsyncActionInvoker<TAction, TConfigurationStore> : WhenEnabledAsyncActionInvoker<TAction, TConfigurationStore>
         where TAction : IAsyncApiAction
         where TConfigurationStore : IExtensionConfigurationStore
     {
 
-        public SecuredAsyncWhenEnabledActionInvoker(TAction action, TConfigurationStore configurationStore) : base(action, configurationStore)
+        public SecuredWhenEnabledAsyncActionInvoker(TAction action, TConfigurationStore configurationStore) : base(action, configurationStore)
         {
         }
 

--- a/source/Server.Extensibility/Resources/Configuration/ConnectivityCheckMessage.cs
+++ b/source/Server.Extensibility/Resources/Configuration/ConnectivityCheckMessage.cs
@@ -1,0 +1,14 @@
+namespace Octopus.Server.Extensibility.Resources.Configuration
+{
+    public class ConnectivityCheckMessage
+    {
+        internal ConnectivityCheckMessage(ConnectivityCheckMessageCategory category, string message)
+        {
+            Category = category;
+            Message = message;
+        }
+
+        public ConnectivityCheckMessageCategory Category { get; }
+        public string Message { get; }
+    }
+}

--- a/source/Server.Extensibility/Resources/Configuration/ConnectivityCheckMessageCategory.cs
+++ b/source/Server.Extensibility/Resources/Configuration/ConnectivityCheckMessageCategory.cs
@@ -1,0 +1,9 @@
+namespace Octopus.Server.Extensibility.Resources.Configuration
+{
+    public enum ConnectivityCheckMessageCategory
+    {
+        Info,
+        Warning,
+        Error
+    }
+}

--- a/source/Server.Extensibility/Resources/Configuration/ConnectivityCheckResponse.cs
+++ b/source/Server.Extensibility/Resources/Configuration/ConnectivityCheckResponse.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Server.Extensibility.Resources.Configuration
+{
+    public class ConnectivityCheckResponse
+    {
+        readonly List<ConnectivityCheckMessage> messages;
+        
+        public ConnectivityCheckResponse()
+        {
+            messages = new List<ConnectivityCheckMessage>();
+        }
+
+        public IEnumerable<ConnectivityCheckMessage> Messages => messages;
+
+        public void AddMessage(ConnectivityCheckMessageCategory category, string message)
+        {
+            messages.Add(new ConnectivityCheckMessage(category, message));
+        }
+    }
+}


### PR DESCRIPTION
We need this in scenarios like the connectivity checks for Jira and Azure DevOps issue trackers.

A common class to be returned by the connectivity checks has also been included here now. It carries a category (Info, Warning, or Error) per message, a bit like a log would, to convey more details of what happened during the check.

Relates to OctopusDeploy/Issues#6097