### PR TITLE
Reference channels by ID or name

### DIFF
--- a/source/Server.Extensibility/HostServices/Model/Projects/IDeploymentAction.cs
+++ b/source/Server.Extensibility/HostServices/Model/Projects/IDeploymentAction.cs
@@ -1,4 +1,5 @@
 ﻿using Octopus.Data.Model;
+using Octopus.Server.Extensibility.HostServices.Model.Channels;
 using Octopus.Server.Extensibility.HostServices.Model.Environments;
 using Octopus.Server.Extensibility.HostServices.Model.WorkerPools;
 
@@ -20,7 +21,7 @@ namespace Octopus.Server.Extensibility.HostServices.Model.Projects
         ReferenceCollection<DeploymentEnvironmentIdOrName> Environments { get; }
         ReferenceCollection<DeploymentEnvironmentIdOrName> ExcludedEnvironments { get; }
 
-        ReferenceCollection Channels { get; }
+        ReferenceCollection<ChannelIdOrName> Channels { get; }
 
         ReferenceCollection TenantTags { get; }
 


### PR DESCRIPTION
This PR changes the channel reference collections to be strongly-typed. This work is to support the "configuration as code" effort.

This PR depends on #35 .