### PR TITLE
Revert TenantTags collection property type

### DIFF
--- a/source/Server.Extensibility/HostServices/Model/Projects/IDeploymentAction.cs
+++ b/source/Server.Extensibility/HostServices/Model/Projects/IDeploymentAction.cs
@@ -22,7 +22,7 @@ namespace Octopus.Server.Extensibility.HostServices.Model.Projects
         ReferenceCollection<DeploymentEnvironmentIdOrName> Environments { get; }
         ReferenceCollection<DeploymentEnvironmentIdOrName> ExcludedEnvironments { get; }
         ReferenceCollection<ChannelIdOrName> Channels { get; }
-        ReferenceCollection<TagCanonicalIdOrName> TenantTags { get; }
+        ReferenceCollection TenantTags { get; }
         PackageReferenceCollection Packages { get; }
     }
 }


### PR DESCRIPTION
This change will be reintroduced once the corresponding change in `OctopusDeploy` is ready.