### PR TITLE
Reintroduce TenantTags collection property type change

### DIFF
--- a/source/Server.Extensibility/HostServices/Model/Projects/IDeploymentAction.cs
+++ b/source/Server.Extensibility/HostServices/Model/Projects/IDeploymentAction.cs
@@ -22,7 +22,7 @@ namespace Octopus.Server.Extensibility.HostServices.Model.Projects
         ReferenceCollection<DeploymentEnvironmentIdOrName> Environments { get; }
         ReferenceCollection<DeploymentEnvironmentIdOrName> ExcludedEnvironments { get; }
         ReferenceCollection<ChannelIdOrName> Channels { get; }
-        ReferenceCollection TenantTags { get; }
+        ReferenceCollection<TagCanonicalIdOrName> TenantTags { get; }
         PackageReferenceCollection Packages { get; }
     }
 }


### PR DESCRIPTION
This PR reintroduces the required change to the TenantTags collection property type.

This PR should not be merged until the downstream consumers (mainly `OctopusDeploy` itself) are ready to accept this change.