### PR TITLE
Composite types for tags

### DIFF
--- a/source/ExtensibilityTests/Tags/TagsCanonicalIdsOrNamesFixture.cs
+++ b/source/ExtensibilityTests/Tags/TagsCanonicalIdsOrNamesFixture.cs
@@ -25,6 +25,7 @@ namespace Node.Extensibility.Tests.Tags
         [TestCase("TagSet-1/Tag-1/")]
         [TestCase("TagSet-1//Tag-1")]
         [TestCase("/TagSet-1/Tag-1")]
+        [TestCase("/TagSet-1/Tag-1/Extra")]
         [TestCase("/TagSet-1")]
         [TestCase("TagSet-1/")]
         public void ShouldThrowForInvalidInputs(string tagCanonicalIdOrName)

--- a/source/Server.Extensibility/HostServices/Model/Projects/IDeploymentAction.cs
+++ b/source/Server.Extensibility/HostServices/Model/Projects/IDeploymentAction.cs
@@ -22,7 +22,7 @@ namespace Octopus.Server.Extensibility.HostServices.Model.Projects
         ReferenceCollection<DeploymentEnvironmentIdOrName> Environments { get; }
         ReferenceCollection<DeploymentEnvironmentIdOrName> ExcludedEnvironments { get; }
         ReferenceCollection<ChannelIdOrName> Channels { get; }
-        ReferenceCollection TenantTags { get; }
+        ReferenceCollection<TagCanonicalIdOrName> TenantTags { get; }
         PackageReferenceCollection Packages { get; }
     }
 }

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalId.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalId.cs
@@ -13,5 +13,8 @@ namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
             if (!TagCanonicalIdOrName.LooksLikeACanonicalIdOrName(value))
                 throw new ArgumentException("Value must look like a canonical tag ID");
         }
+
+        public TagSetId TagSetId => new TagSetId(Value.Split("/")[0]);
+
     }
 }

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalId.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalId.cs
@@ -12,9 +12,19 @@ namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
         {
             if (!TagCanonicalIdOrName.LooksLikeACanonicalIdOrName(value))
                 throw new ArgumentException("Value must look like a canonical tag ID");
+
+            var tokens = value.Split("/");
+            TagSetId = new TagSetId(tokens[0]);
+            TagId = new TagId(tokens[1]);
         }
 
-        public TagSetId TagSetId => new TagSetId(Value.Split("/")[0]);
+        public TagCanonicalId(TagSetId tagSetId, TagId tagId) : base($"{tagSetId.Value}/{tagId.Value}")
+        {
+            TagSetId = tagSetId;
+            TagId = tagId;
+        }
 
+        public TagSetId TagSetId { get; }
+        public TagId TagId { get; }
     }
 }

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalIdOrName.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalIdOrName.cs
@@ -10,7 +10,12 @@ namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
         {
             if (!LooksLikeACanonicalIdOrName(value))
                 throw new ArgumentException("Value must look like a canonical tag ID or name");
+
+            var tokens = value.Split("/");
+            TagSetIdOrName = new TagSetIdOrName( tokens[0]);
         }
+
+        public TagSetIdOrName TagSetIdOrName { get; }
 
         internal static bool LooksLikeACanonicalIdOrName(string s)
         {

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalIdOrName.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalIdOrName.cs
@@ -10,12 +10,9 @@ namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
         {
             if (!LooksLikeACanonicalIdOrName(value))
                 throw new ArgumentException("Value must look like a canonical tag ID or name");
-
-            var tokens = value.Split("/");
-            TagSetIdOrName = new TagSetIdOrName( tokens[0]);
         }
 
-        public TagSetIdOrName TagSetIdOrName { get; }
+        public TagSetIdOrName TagSetIdOrName => new TagSetIdOrName(Value.Split("/")[0]);
 
         internal static bool LooksLikeACanonicalIdOrName(string s)
         {

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalName.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalName.cs
@@ -13,5 +13,7 @@ namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
             if (!TagCanonicalIdOrName.LooksLikeACanonicalIdOrName(value))
                 throw new ArgumentException("Value must look like a canonical tag name");
         }
+
+        public TagSetName TagSetName => new TagSetName(Value.Split("/")[0]);
     }
 }

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalName.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalName.cs
@@ -12,9 +12,19 @@ namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
         {
             if (!TagCanonicalIdOrName.LooksLikeACanonicalIdOrName(value))
                 throw new ArgumentException("Value must look like a canonical tag name");
+
+            var tokens = value.Split("/");
+            TagSetName = new TagSetName(tokens[0]);
+            TagName = new TagName(tokens[1]);
         }
 
-        public TagSetName TagSetName => new TagSetName(Value.Split("/")[0]);
-        public TagName TagName => new TagName(Value.Split("/")[1]);
+        public TagCanonicalName(TagSetName tagSetName, TagName tagName) : base($"{tagSetName.Value}/{tagName.Value}")
+        {
+            TagSetName = tagSetName;
+            TagName = tagName;
+        }
+
+        public TagSetName TagSetName { get; }
+        public TagName TagName { get; }
     }
 }

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalName.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagCanonicalName.cs
@@ -15,5 +15,6 @@ namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
         }
 
         public TagSetName TagSetName => new TagSetName(Value.Split("/")[0]);
+        public TagName TagName => new TagName(Value.Split("/")[1]);
     }
 }

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagId.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagId.cs
@@ -3,12 +3,12 @@ using Octopus.TinyTypes;
 
 namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
 {
-    public class TagName : CaseInsensitiveStringTinyType
+    public class TagId : CaseInsensitiveStringTinyType
     {
-        public TagName(string value) : base(value)
+        public TagId(string value) : base(value)
         {
             if (!TagSetIdOrName.LooksLikeASingleTokenIdOrName(value))
-                throw new ArgumentException("Value must look like a single-token Tag name");
+                throw new ArgumentException("Value must look like a single-token Tag ID");
         }
     }
 }

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagName.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagName.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
+{
+    public class TagName : CaseInsensitiveStringTinyType
+    {
+        public TagName(string value) : base(value)
+        {
+            if (!TagSetIdOrName.LooksLikeASingleTokenIdOrName(value))
+                throw new ArgumentException("Value must look like a canonical Tag name");
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagSetId.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagSetId.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
+{
+    public class TagSetId : CaseInsensitiveStringTinyType
+    {
+        public TagSetId(string value) : base(value)
+        {
+            if (!TagSetIdOrName.LooksLikeASingleTokenIdOrName(value))
+                throw new ArgumentException("Value must look like a canonical TagSet ID");
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagSetIdOrName.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagSetIdOrName.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
+{
+    public class TagSetIdOrName : CaseInsensitiveStringTinyType
+    {
+        public TagSetIdOrName(string value) : base(value)
+        {
+            if (!LooksLikeASingleTokenIdOrName(value))
+                throw new ArgumentException("Value must look like a canonical TagSet ID or name");
+        }
+
+        internal static bool LooksLikeASingleTokenIdOrName(string s)
+        {
+            var tokens = s.Split("/");
+            if (tokens.Length != 1) return false;
+            if (tokens.Any(string.IsNullOrWhiteSpace)) return false;
+            return true;
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/TagSets/TagSetName.cs
+++ b/source/Server.Extensibility/HostServices/Model/TagSets/TagSetName.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.TagSets
+{
+    public class TagSetName : CaseInsensitiveStringTinyType
+    {
+        public TagSetName(string value) : base(value)
+        {
+            if (!TagSetIdOrName.LooksLikeASingleTokenIdOrName(value))
+                throw new ArgumentException("Value must look like a canonical TagSet name");
+        }
+    }
+}


### PR DESCRIPTION
This PR reintroduces composite types for tags. The change was previously reverted until the downstream consumers were in a state to accept this update.