### PR TITLE
Expose CORS whitelist in WebPortalConfiguration store for AD integration (9.x.x server 2020.3)

### DIFF
--- a/source/Server.Extensibility/HostServices/Web/IWebPortalConfigurationStore.cs
+++ b/source/Server.Extensibility/HostServices/Web/IWebPortalConfigurationStore.cs
@@ -6,5 +6,7 @@
         ///     Returns the web portal configuration for the current Node.
         /// </summary>
         NodeWebPortalConfiguration GetCurrentNodeWebPortalConfiguration();
+        
+        string GetCorsWhitelist();
     }
 }


### PR DESCRIPTION
This PR exposes the GetCorsWhitelist method from the web portal configuration for the AD extension as it hosts a separate endpoint to deal with certain quirks around integrated auth.

This PR coincides to the version pinned in Server 2020.3.