### PR TITLE
Expose CORS whitelist in WebPortalConfiguration store for AD integration

### DIFF
--- a/source/Server.Extensibility/HostServices/Web/IWebPortalConfigurationStore.cs
+++ b/source/Server.Extensibility/HostServices/Web/IWebPortalConfigurationStore.cs
@@ -6,5 +6,7 @@
         /// Returns the web portal configuration for the current Node.
         /// </summary>
         NodeWebPortalConfiguration GetCurrentNodeWebPortalConfiguration();
+        
+        string GetCorsWhitelist();
     }
 }


### PR DESCRIPTION
This PR exposes the GetCorsWhitelist method from the web portal configuration needed for our AD extension as it has a separate web host and doesn't inherit all the configuration from server.