### PR TITLE
Feeds: actions should refer to package feeds by name

### DIFF
--- a/source/Server.Extensibility/HostServices/Model/Accounts/AccountId.cs
+++ b/source/Server.Extensibility/HostServices/Model/Accounts/AccountId.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Accounts
+{
+    public class AccountId : CaseInsensitiveStringTinyType
+    {
+        public AccountId(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Accounts/AccountIdOrName.cs
+++ b/source/Server.Extensibility/HostServices/Model/Accounts/AccountIdOrName.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Accounts
+{
+    public class AccountIdOrName : CaseInsensitiveStringTinyType
+    {
+        public AccountIdOrName(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Accounts/AccountName.cs
+++ b/source/Server.Extensibility/HostServices/Model/Accounts/AccountName.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Accounts
+{
+    public class AccountName : CaseInsensitiveStringTinyType
+    {
+        public AccountName(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Feeds/FeedId.cs
+++ b/source/Server.Extensibility/HostServices/Model/Feeds/FeedId.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Feeds
+{
+    public class FeedId : CaseInsensitiveStringTinyType
+    {
+        public FeedId(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Feeds/FeedIdOrName.cs
+++ b/source/Server.Extensibility/HostServices/Model/Feeds/FeedIdOrName.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Feeds
+{
+    public class FeedIdOrName : CaseInsensitiveStringTinyType
+    {
+        public FeedIdOrName(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Feeds/FeedName.cs
+++ b/source/Server.Extensibility/HostServices/Model/Feeds/FeedName.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Feeds
+{
+    public class FeedName : CaseInsensitiveStringTinyType
+    {
+        public FeedName(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/PackageReference.cs
+++ b/source/Server.Extensibility/HostServices/Model/PackageReference.cs
@@ -130,7 +130,7 @@ namespace Octopus.Server.Extensibility.HostServices.Model
         /// Feed ID, name or a variable-expression
         /// </summary>
         [JsonProperty("FeedId")] // This is named FeedId for backward-compatibility as we don't yet want to change the underlying database JSON/schema.
-        public FeedIdOrName FeedIdOrName { get; set; }
+        public FeedIdOrName? FeedIdOrName { get; set; }
 
         /// <summary>
         ///     The package-acquisition location.

--- a/source/Server.Extensibility/HostServices/Model/PackageReference.cs
+++ b/source/Server.Extensibility/HostServices/Model/PackageReference.cs
@@ -130,7 +130,7 @@ namespace Octopus.Server.Extensibility.HostServices.Model
         /// Feed ID, name or a variable-expression
         /// </summary>
         [JsonProperty("FeedId")] // This is named FeedId for backward-compatibility as we don't yet want to change the underlying database JSON/schema.
-        public FeedIdOrName FeedIdOrName { get; set; } = new FeedIdOrName(string.Empty);
+        public FeedIdOrName FeedIdOrName { get; set; }
 
         /// <summary>
         ///     The package-acquisition location.

--- a/source/Server.Extensibility/HostServices/Model/PackageReference.cs
+++ b/source/Server.Extensibility/HostServices/Model/PackageReference.cs
@@ -126,13 +126,11 @@ namespace Octopus.Server.Extensibility.HostServices.Model
         /// </summary>
         public string PackageId { get; set; } = string.Empty;
 
-        ///// <summary>
-        /////     Feed ID or a variable-expression
-        ///// </summary>
-        //public string FeedId { get; set; } = string.Empty;
-
+        /// <summary>
+        /// Feed ID, name or a variable-expression
+        /// </summary>
         [JsonProperty("FeedId")] // This is named FeedId for backward-compatibility as we don't yet want to change the underlying database JSON/schema.
-        public FeedIdOrName FeedIdOrName { get; set; }
+        public FeedIdOrName FeedIdOrName { get; set; } = new FeedIdOrName(string.Empty);
 
         /// <summary>
         ///     The package-acquisition location.

--- a/source/Server.Extensibility/HostServices/Model/PackageReference.cs
+++ b/source/Server.Extensibility/HostServices/Model/PackageReference.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Octopus.Data.Model;
+using Octopus.Server.Extensibility.HostServices.Model.Feeds;
 using Octopus.Server.Extensibility.Resources;
 
 namespace Octopus.Server.Extensibility.HostServices.Model
@@ -25,10 +26,10 @@ namespace Octopus.Server.Extensibility.HostServices.Model
         /// </summary>
         /// <param name="name">The package-reference name.</param>
         /// <param name="packageId">The package ID or a variable-expression</param>
-        /// <param name="feedId">The feed ID or a variable-expression</param>
+        /// <param name="feedIdOrName">The feed ID or a variable-expression</param>
         /// <param name="acquisitionLocation">The location the package should be acquired</param>
-        public PackageReference(string? name, string packageId, string feedId, PackageAcquisitionLocation acquisitionLocation)
-            : this(name, packageId, feedId, acquisitionLocation.ToString())
+        public PackageReference(string? name, string packageId, FeedIdOrName feedIdOrName, PackageAcquisitionLocation acquisitionLocation)
+            : this(name, packageId, feedIdOrName, acquisitionLocation.ToString())
         {
         }
 
@@ -37,14 +38,14 @@ namespace Octopus.Server.Extensibility.HostServices.Model
         /// </summary>
         /// <param name="name">The package-reference name.</param>
         /// <param name="packageId">The package ID or a variable-expression</param>
-        /// <param name="feedId">The feed ID or a variable-expression</param>
+        /// <param name="feedIdOrName">The feed ID or a variable-expression</param>
         /// <param name="acquisitionLocation">The location the package should be acquired.
         /// May be one <see cref="PackageAcquisitionLocation" /> or a variable-expression.</param>
-        public PackageReference(string? name, string packageId, string feedId, string acquisitionLocation)
+        public PackageReference(string? name, string packageId, FeedIdOrName feedIdOrName, string acquisitionLocation)
             : this(null,
                    name,
                    packageId,
-                   feedId,
+                   feedIdOrName,
                    acquisitionLocation)
         {
         }
@@ -56,14 +57,14 @@ namespace Octopus.Server.Extensibility.HostServices.Model
         public PackageReference(string? id,
                                 string? name,
                                 string packageId,
-                                string feedId,
+                                FeedIdOrName feedIdOrName,
                                 string acquisitionLocation)
             : this()
         {
             if (!string.IsNullOrEmpty(id)) Id = id;
 
             PackageId = packageId;
-            FeedId = feedId;
+            FeedIdOrName = feedIdOrName;
             AcquisitionLocation = acquisitionLocation;
             Name = name ?? string.Empty;
         }
@@ -71,31 +72,31 @@ namespace Octopus.Server.Extensibility.HostServices.Model
         /// <summary>
         ///     Constructs a primary package (an un-named package reference)
         /// </summary>
-        public PackageReference(string packageId, string feedId, PackageAcquisitionLocation acquisitionLocation)
-            : this(null, packageId, feedId, acquisitionLocation)
+        public PackageReference(string packageId, FeedIdOrName feedIdOrName, PackageAcquisitionLocation acquisitionLocation)
+            : this(null, packageId, feedIdOrName, acquisitionLocation)
         {
         }
 
         /// <summary>
         ///     Constructs a primary package (an un-named package reference)
         /// </summary>
-        public PackageReference(string packageId, string feedId, string acquisitionLocation)
-            : this(null, packageId, feedId, acquisitionLocation)
+        public PackageReference(string packageId, FeedIdOrName feedIdOrName, string acquisitionLocation)
+            : this(null, packageId, feedIdOrName, acquisitionLocation)
         {
         }
 
         /// <summary>
         ///     Constructs a primary package (an un-named package reference)
         /// </summary>
-        public PackageReference(string packageId, string feedId)
-            : this(packageId, feedId, PackageAcquisitionLocation.Server)
+        public PackageReference(string packageId, FeedIdOrName feedIdOrName)
+            : this(packageId, feedIdOrName, PackageAcquisitionLocation.Server)
         {
         }
 
         /// <summary>
         ///     In the scenario where we are migrating from 2.6 instances, we set the ID of the package-reference
         ///     to the same ID as the deployment-action.
-        ///     This was the least-bad option that let the migrator do it's thing when migrating project
+        ///     This was the least-bad option that let the migrator do its thing when migrating project
         ///     release-creation-strategy and versioning-strategy.
         /// </summary>
         public PackageReference(string id) : this()
@@ -125,10 +126,13 @@ namespace Octopus.Server.Extensibility.HostServices.Model
         /// </summary>
         public string PackageId { get; set; } = string.Empty;
 
-        /// <summary>
-        ///     Feed ID or a variable-expression
-        /// </summary>
-        public string FeedId { get; set; } = string.Empty;
+        ///// <summary>
+        /////     Feed ID or a variable-expression
+        ///// </summary>
+        //public string FeedId { get; set; } = string.Empty;
+
+        [JsonProperty("FeedId")] // This is named FeedId for backward-compatibility as we don't yet want to change the underlying database JSON/schema.
+        public FeedIdOrName FeedIdOrName { get; set; }
 
         /// <summary>
         ///     The package-acquisition location.
@@ -147,7 +151,7 @@ namespace Octopus.Server.Extensibility.HostServices.Model
             return new PackageReference(Id,
                                         Name,
                                         PackageId,
-                                        FeedId,
+                                        FeedIdOrName,
                                         AcquisitionLocation)
             {
                 Properties = new Dictionary<string, string>(Properties)

--- a/source/Server.Extensibility/HostServices/Model/Projects/ProjectId.cs
+++ b/source/Server.Extensibility/HostServices/Model/Projects/ProjectId.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Projects
+{
+    public class ProjectId : CaseInsensitiveStringTinyType
+    {
+        public ProjectId(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Projects/ProjectIdOrName.cs
+++ b/source/Server.Extensibility/HostServices/Model/Projects/ProjectIdOrName.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Projects
+{
+    public class ProjectIdOrName : CaseInsensitiveStringTinyType
+    {
+        public ProjectIdOrName(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Projects/ProjectName.cs
+++ b/source/Server.Extensibility/HostServices/Model/Projects/ProjectName.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Projects
+{
+    public class ProjectName : CaseInsensitiveStringTinyType
+    {
+        public ProjectName(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Teams/TeamId.cs
+++ b/source/Server.Extensibility/HostServices/Model/Teams/TeamId.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Teams
+{
+    public class TeamId : CaseInsensitiveStringTinyType
+    {
+        public TeamId(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Teams/TeamIdOrName.cs
+++ b/source/Server.Extensibility/HostServices/Model/Teams/TeamIdOrName.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Teams
+{
+    public class TeamIdOrName : CaseInsensitiveStringTinyType
+    {
+        public TeamIdOrName(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/Teams/TeamName.cs
+++ b/source/Server.Extensibility/HostServices/Model/Teams/TeamName.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model.Teams
+{
+    public class TeamName : CaseInsensitiveStringTinyType
+    {
+        public TeamName(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/HostServices/Model/TinyTypeExtensionMethods.cs
+++ b/source/Server.Extensibility/HostServices/Model/TinyTypeExtensionMethods.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Octopus.TinyTypes;
+
+namespace Octopus.Server.Extensibility.HostServices.Model
+{
+    public static class TinyTypeExtensionMethods
+    {
+        public static TTinyType? ToTinyType<TTinyType>(this string item) where TTinyType : TinyType<string>
+        {
+            // ReSharper disable once ConvertIfStatementToReturnStatement
+            if (item == null) return null;
+            return (TTinyType)Activator.CreateInstance(typeof(TTinyType), item);
+        }
+    }
+}


### PR DESCRIPTION
Updates required to support [this Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/7330)

What's changed?
- We've added tinytypes for Teams, Accounts, Feeds and Projects (in preparation for the warnings API work happening)
- Updated FeedId references to FeedIdOrName

These changes will be squashed.