### PR TITLE
Moving everything away from ILogWithContext

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -3,3 +3,4 @@ updates:
   - package-ecosystem: "nuget"
     ignore:
       - dependency-name: "Autofac*"
+      - dependency-name: "Octopus*"

--- a/source/Server.Extensibility/Diagnostics/CorrelationId.cs
+++ b/source/Server.Extensibility/Diagnostics/CorrelationId.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Octopus.Server.Extensibility.Diagnostics
+{
+    public class CorrelationId
+    {
+        public CorrelationId()
+        {
+            Id = Guid.NewGuid().ToString("N");
+        }
+
+        public CorrelationId(string id)
+        {
+            Id = id;
+        }
+
+        public string Id { get; }
+
+        public override string ToString()
+            => Id;
+    }
+}

--- a/source/Server.Extensibility/Domain/Deployments/DeploymentEvent.cs
+++ b/source/Server.Extensibility/Domain/Deployments/DeploymentEvent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Octopus.Diagnostics;
+using Octopus.Server.Extensibility.HostServices.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Domain.Events;
 using Octopus.Server.Extensibility.HostServices.Model.Projects;
 

--- a/source/Server.Extensibility/Domain/Deployments/DeploymentEvent.cs
+++ b/source/Server.Extensibility/Domain/Deployments/DeploymentEvent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Domain.Events;
 using Octopus.Server.Extensibility.HostServices.Model.Projects;
 
@@ -16,13 +17,15 @@ namespace Octopus.Server.Extensibility.Domain.Deployments
 
     public class DeploymentEvent : DomainEvent
     {
-        public DeploymentEvent(DeploymentEventType eventType, IDeployment deployment)
+        public DeploymentEvent(DeploymentEventType eventType, IDeployment deployment, ITaskLog taskLog)
         {
             EventType = eventType;
             Deployment = deployment;
+            TaskLog = taskLog;
         }
 
         public DeploymentEventType EventType { get; }
         public IDeployment Deployment { get; }
+        public ITaskLog TaskLog { get; }
     }
 }

--- a/source/Server.Extensibility/HostServices/Diagnostics/ITaskLog.cs
+++ b/source/Server.Extensibility/HostServices/Diagnostics/ITaskLog.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Octopus.Diagnostics;
+
+namespace Octopus.Server.Extensibility.HostServices.Diagnostics
+{
+    public interface ITaskLog : ILog, IDisposable
+    {
+        bool IsVerboseEnabled { get; }
+        bool IsErrorEnabled { get; }
+        bool IsFatalEnabled { get; }
+        bool IsInfoEnabled { get; }
+        bool IsTraceEnabled { get; }
+        bool IsWarnEnabled { get; }
+
+        /// <summary>
+        /// Opens a new child block for logging.
+        /// </summary>
+        /// <param name="messageText">Title of the new block.</param>
+        /// <returns>A child <see cref="ITaskLog" />.</returns>
+        ITaskLog CreateBlock(string messageText);
+
+        /// <summary>
+        /// Opens a new child block for logging.
+        /// </summary>
+        /// <param name="messageFormat">Format string for the message.</param>
+        /// <param name="args">Arguments for the format string.</param>
+        /// <returns>A child <see cref="ITaskLog" />.</returns>
+        [StringFormatMethod("messageFormat")]
+        ITaskLog CreateBlock(string messageFormat, params object[] args);
+
+        /// <summary>
+        /// Creates a child context with the same correlationId and additional sensitive values.
+        /// </summary>
+        /// <param name="sensitiveValues">Additional sensitive values.</param>
+        /// <returns>A new child task log</returns>
+        ITaskLog ChildContext(string[] sensitiveValues);
+
+        /// <summary>
+        /// Plans a new block of output that will be used in the future for grouping child blocks for logging.
+        /// </summary>
+        /// <param name="messageText">Title of the new block.</param>
+        /// <returns>A child <see cref="ITaskLog" />.</returns>
+        ITaskLog PlanGroupedBlock(string messageText);
+
+        /// <summary>
+        /// Plans a new block of log output that will be used in the future. This is typically used for high-level log
+        /// information, such as the steps in a big deployment process.
+        /// </summary>
+        /// <param name="messageText">Title of the new block.</param>
+        /// <returns>A child <see cref="ITaskLog" />.</returns>
+        ITaskLog PlanFutureBlock(string messageText);
+
+        /// <summary>
+        /// Plans a new block of log output that will be used in the future. This is typically used for high-level log
+        /// information, such as the steps in a big deployment process.
+        /// </summary>
+        /// <param name="messageFormat">Format string for the message.</param>
+        /// <param name="args">Arguments for the format string.</param>
+        /// <returns>A child <see cref="ITaskLog" />.</returns>
+        [StringFormatMethod("messageFormat")]
+        ITaskLog PlanFutureBlock(string messageFormat, params object[] args);
+
+        /// <summary>
+        /// Marks the current block as abandoned. Abandoned blocks won't be shown in the task log.
+        /// </summary>
+        void Abandon();
+
+        /// <summary>
+        /// If a block was previously abandoned using <see cref="Abandon" />, calling <see cref="Reinstate" /> will un-abandon
+        /// it.
+        /// </summary>
+        void Reinstate();
+
+        /// <summary>
+        /// Marks the current block as finished. If there were any errors, it will be finished with errors. If there were no
+        /// errors, it will be assumed to be successful.
+        /// </summary>
+        void Finish();
+
+        bool IsEnabled(LogCategory category);
+
+        void UpdateProgress(int progressPercentage, string messageText);
+
+        [StringFormatMethod("messageFormat")]
+        void UpdateProgressFormat(int progressPercentage, string messageFormat, params object[] args);
+    }
+}

--- a/source/Server.Extensibility/HostServices/Diagnostics/ITaskLog.cs
+++ b/source/Server.Extensibility/HostServices/Diagnostics/ITaskLog.cs
@@ -3,7 +3,7 @@ using Octopus.Diagnostics;
 
 namespace Octopus.Server.Extensibility.HostServices.Diagnostics
 {
-    public interface ITaskLog : ILog, IDisposable
+    public interface ITaskLog : ILog
     {
         bool IsVerboseEnabled { get; }
         bool IsErrorEnabled { get; }

--- a/source/Server.Extensibility/HostServices/Mapping/ICanonicalTagNameMapper.cs
+++ b/source/Server.Extensibility/HostServices/Mapping/ICanonicalTagNameMapper.cs
@@ -1,10 +1,11 @@
 using System;
+using Octopus.Diagnostics;
 
 namespace Octopus.Server.Extensibility.HostServices.Mapping
 {
     public interface ICanonicalTagNameMapper
     {
         string GetTagIdFromCanonicalTagName(string canonicalTagName);
-        string GetCanonicalTagNameFromTagId(string tagId);
+        string? GetCanonicalTagNameFromTagId(string canonicalTagId, ILog log);
     }
 }

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.4.2-enh-logwithconte0006" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.4.2-enh-logwithconte0009" />
     <PackageReference Include="Octopus.TinyTypes" Version="0.1.345" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.3" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.4.2-enh-logwithconte0006" />
     <PackageReference Include="Octopus.TinyTypes" Version="0.1.345" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.3" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.4.2-enh-logwithconte0009" />
+    <PackageReference Include="Octopus.Diagnostics" Version="2.0.0" />
     <PackageReference Include="Octopus.TinyTypes" Version="0.1.345" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.3" />
     <PackageReference Include="Autofac" Version="4.9.4" />

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -26,15 +26,12 @@
     <None Remove="Extensions\Infrastructure\Web\Content\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="2.0.0" />
-    <PackageReference Include="Octopus.TinyTypes" Version="0.1.345" />
-    <PackageReference Include="Octopus.Versioning" Version="4.3.3" />
     <PackageReference Include="Autofac" Version="4.9.4" />
+    <PackageReference Include="Octopus.Data" Version="5.3.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="2.0.0" />
     <PackageReference Include="Octopus.TinyTypes" Version="0.1.411" />
     <PackageReference Include="Octopus.Versioning" Version="5.0.1" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="Octopus.Data" Version="5.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
There is now a new `ITaskLog` that is defined in here, which all of the server components and extensions can use. Server holds the implementation of this interface.