### PR TITLE
Add BroadcastRequest method to mediator. Bump Octopus.Server.MessageContracts to support.

### DIFF
--- a/source/Server.Extensibility/Mediator/IMediator.cs
+++ b/source/Server.Extensibility/Mediator/IMediator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Server.MessageContracts;
@@ -13,6 +14,10 @@ namespace Octopus.Server.Extensibility.Mediator
 
         Task<TResponse> Request<TRequest, TResponse>(IRequest<TRequest, TResponse> request, CancellationToken cancellationToken)
             where TRequest : IRequest<TRequest, TResponse>
+            where TResponse : IResponse;
+
+        IAsyncEnumerable<TResponse> BroadcastRequest<TRequest, TResponse>(IBroadcastRequest<TRequest, TResponse> request, CancellationToken cancellationToken)
+            where TRequest : IBroadcastRequest<TRequest, TResponse>
             where TResponse : IResponse;
 
         Task Publish<TEvent>(TEvent @event, CancellationToken cancellationToken)

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Octopus.Data" Version="7.1.5" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.2" />
     <PackageReference Include="Octopus.Ocl" Version="0.4.843" />
-    <PackageReference Include="Octopus.Server.MessageContracts" Version="0.4.57" />
+    <PackageReference Include="Octopus.Server.MessageContracts" Version="0.5.100" />
     <PackageReference Include="Octopus.TinyTypes" Version="2.2.26" />
     <PackageReference Include="Octopus.Versioning" Version="5.1.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
This PR adds the `BroadcastRequest` method to `IMediator` to support asking "Does anybody care about x?" kinds of questions.

* There is no obligation for any extensions to handle these requests.
* Extensions which do implement handlers can decline to respond via returning an empty async enumerable (i.e. `yield break;`)
* Likewise, extensions which wish to venture multiple opinions may do so by yielding multiple response payloads.