### PR TITLE
Moving some parts of the extensibility to be async

### DIFF
--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationDocumentStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationDocumentStoreAsync.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+using Octopus.Data.Model.Configuration;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public abstract class ConfigurationDocumentStoreAsync<TConfiguration> : IConfigurationDocumentStoreAsync<TConfiguration>
+        where TConfiguration : ConfigurationDocument, new()
+    {
+        readonly IConfigurationStoreAsync configurationStore;
+
+        protected ConfigurationDocumentStoreAsync(IConfigurationStoreAsync configurationStore)
+        {
+            this.configurationStore = configurationStore;
+        }
+
+        public abstract string Id { get; }
+
+        public async Task<object> GetConfiguration()
+        {
+            var doc = await configurationStore.Get<TConfiguration>(Id);
+            return doc ?? new TConfiguration();
+        }
+
+        public async Task SetConfiguration(object config)
+        {
+            if (config is TConfiguration == false)
+                throw new ArgumentException($"Given config type is {config.GetType()}, but {typeof(TConfiguration)} was expected");
+
+            var existingConfig = await configurationStore.Get<TConfiguration>(Id);
+            if (existingConfig == null)
+                await configurationStore.Create((TConfiguration)config);
+            else
+                await configurationStore.Update((TConfiguration)config);
+
+            OnConfigurationChanged();
+        }
+
+        protected async Task<TProperty> GetProperty<TProperty>(Func<TConfiguration, TProperty> prop)
+        {
+            var doc = await configurationStore.Get<TConfiguration>(Id);
+            if (doc == null)
+                throw new InvalidOperationException($"{Id} configuration initialization has not executed");
+
+            return prop(doc);
+        }
+
+        protected async Task SetProperty(Action<TConfiguration> callback)
+        {
+            var doc = await configurationStore.Get<TConfiguration>(Id);
+            if (doc == null)
+                throw new InvalidOperationException($"{Id} configuration initialization has not executed");
+
+            callback(doc);
+            await configurationStore.Update(doc);
+            OnConfigurationChanged();
+        }
+
+        protected virtual void OnConfigurationChanged()
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationSettingsAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationSettingsAsync.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Data.Model.Configuration;
 using Octopus.Server.Extensibility.HostServices.Mapping;
@@ -24,17 +25,17 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
         public abstract string Description { get; }
         public Type MetadataResourceType => typeof(TResource);
 
-        public virtual async Task<object> GetConfiguration()
+        public virtual async Task<object> GetConfiguration(CancellationToken cancellationToken)
         {
-            return await ConfigurationDocumentStore.GetConfiguration();
+            return await ConfigurationDocumentStore.GetConfiguration(cancellationToken);
         }
 
-        public virtual async Task SetConfiguration(object config)
+        public virtual async Task SetConfiguration(object config, CancellationToken cancellationToken)
         {
-            await ConfigurationDocumentStore.SetConfiguration(config);
+            await ConfigurationDocumentStore.SetConfiguration(config, cancellationToken);
         }
 
-        public abstract IAsyncEnumerable<IConfigurationValue> GetConfigurationValues();
+        public abstract IAsyncEnumerable<IConfigurationValue> GetConfigurationValues(CancellationToken cancellationToken = default);
 
         public abstract void BuildMappings(IResourceMappingsBuilder builder);
     }
@@ -50,8 +51,8 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 
         public Type MetadataResourceType => typeof(TResource);
 
-        public abstract IAsyncEnumerable<IConfigurationValue> GetConfigurationValues();
+        public abstract IAsyncEnumerable<IConfigurationValue> GetConfigurationValues(CancellationToken cancellationToken = default);
 
-        public abstract Task<object> GetConfigurationResource();
+        public abstract Task<object> GetConfigurationResource(CancellationToken cancellationToken);
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationSettingsAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ConfigurationSettingsAsync.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Octopus.Data.Model.Configuration;
+using Octopus.Server.Extensibility.HostServices.Mapping;
+using Octopus.Server.MessageContracts;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public abstract class ConfigurationSettingsAsync<TConfiguration, TResource, TDocumentStore> : IHasConfigurationSettingsAsync
+        where TConfiguration : ConfigurationDocument, new()
+        where TResource : IResource
+        where TDocumentStore : IConfigurationDocumentStoreAsync<TConfiguration>
+    {
+        protected ConfigurationSettingsAsync(TDocumentStore configurationDocumentStore)
+        {
+            ConfigurationDocumentStore = configurationDocumentStore;
+        }
+
+        protected TDocumentStore ConfigurationDocumentStore { get; }
+
+        public abstract string Id { get; }
+        public abstract string ConfigurationSetName { get; }
+        public abstract string Description { get; }
+        public Type MetadataResourceType => typeof(TResource);
+
+        public virtual async Task<object> GetConfiguration()
+        {
+            return await ConfigurationDocumentStore.GetConfiguration();
+        }
+
+        public virtual async Task SetConfiguration(object config)
+        {
+            await ConfigurationDocumentStore.SetConfiguration(config);
+        }
+
+        public abstract IAsyncEnumerable<IConfigurationValue> GetConfigurationValues();
+
+        public abstract void BuildMappings(IResourceMappingsBuilder builder);
+    }
+
+    public abstract class ConfigurationSettingsAsync<TResource> : IHasAggregatedConfigurationSettingsAsync
+        where TResource : IResource
+    {
+        public abstract string Id { get; }
+
+        public abstract string ConfigurationSetName { get; }
+
+        public abstract string Description { get; }
+
+        public Type MetadataResourceType => typeof(TResource);
+
+        public abstract IAsyncEnumerable<IConfigurationValue> GetConfigurationValues();
+
+        public abstract Task<object> GetConfigurationResource();
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ExtensionConfigurationSettingsAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ExtensionConfigurationSettingsAsync.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public abstract class
+        ExtensionConfigurationSettingsAsync<TConfiguration, TResource, TDocumentStore> : ConfigurationSettingsAsync<TConfiguration
+            , TResource, TDocumentStore>
+        where TConfiguration : ExtensionConfigurationDocument, new()
+        where TResource : ExtensionConfigurationResource
+        where TDocumentStore : IConfigurationDocumentStoreAsync<TConfiguration>
+    {
+        protected ExtensionConfigurationSettingsAsync(TDocumentStore configurationDocumentStore) : base(configurationDocumentStore)
+        {
+        }
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ExtensionConfigurationStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ExtensionConfigurationStoreAsync.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public abstract class ExtensionConfigurationStoreAsync<TConfiguration> : ConfigurationDocumentStoreAsync<TConfiguration>,
+                                                                             IExtensionConfigurationStoreAsync<TConfiguration>
+        where TConfiguration : ExtensionConfigurationDocument, new()
+    {
+        protected ExtensionConfigurationStoreAsync(IConfigurationStoreAsync configurationStore) : base(configurationStore)
+        {
+        }
+
+        public async Task<bool> GetIsEnabled()
+        {
+            return await GetProperty(doc => doc.IsEnabled);
+        }
+
+        public virtual async Task SetIsEnabled(bool isEnabled)
+        {
+            await SetProperty(doc => doc.IsEnabled = isEnabled);
+        }
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ExtensionConfigurationStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/ExtensionConfigurationStoreAsync.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
@@ -11,14 +12,14 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
         {
         }
 
-        public async Task<bool> GetIsEnabled()
+        public async Task<bool> GetIsEnabled(CancellationToken cancellationToken)
         {
-            return await GetProperty(doc => doc.IsEnabled);
+            return await GetProperty(doc => doc.IsEnabled, cancellationToken);
         }
 
-        public virtual async Task SetIsEnabled(bool isEnabled)
+        public virtual async Task SetIsEnabled(bool isEnabled, CancellationToken cancellationToken)
         {
-            await SetProperty(doc => doc.IsEnabled = isEnabled);
+            await SetProperty(doc => doc.IsEnabled = isEnabled, cancellationToken);
         }
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IConfigurationDocumentStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IConfigurationDocumentStoreAsync.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Data.Model.Configuration;
 
@@ -11,7 +12,7 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 
     public interface IConfigurationDocumentStoreAsync
     {
-        Task<object> GetConfiguration();
-        Task SetConfiguration(object config);
+        Task<object> GetConfiguration(CancellationToken cancellationToken);
+        Task SetConfiguration(object config, CancellationToken cancellationToken);
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IConfigurationDocumentStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IConfigurationDocumentStoreAsync.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Octopus.Data.Model.Configuration;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public interface IConfigurationDocumentStoreAsync<TConfiguration> : IConfigurationDocumentStoreAsync
+        where TConfiguration : ConfigurationDocument, new()
+    {
+    }
+
+    public interface IConfigurationDocumentStoreAsync
+    {
+        Task<object> GetConfiguration();
+        Task SetConfiguration(object config);
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IConfigurationStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IConfigurationStoreAsync.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Data.Model.Configuration;
 
@@ -6,16 +7,16 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
     public interface IConfigurationStoreAsync
     {
-        Task<TDocument?> Get<TDocument>(string id) where TDocument : ConfigurationDocument;
+        Task<TDocument?> Get<TDocument>(string id, CancellationToken cancellationToken) where TDocument : ConfigurationDocument;
 
-        Task Create<TDocument>(TDocument document) where TDocument : ConfigurationDocument;
+        Task Create<TDocument>(TDocument document, CancellationToken cancellationToken) where TDocument : ConfigurationDocument;
 
-        Task Update<TDocument>(TDocument document) where TDocument : ConfigurationDocument;
+        Task Update<TDocument>(TDocument document, CancellationToken cancellationToken) where TDocument : ConfigurationDocument;
 
-        Task Delete<TDocument>(TDocument document) where TDocument : ConfigurationDocument;
+        Task Delete<TDocument>(TDocument document, CancellationToken cancellationToken) where TDocument : ConfigurationDocument;
 
-        Task DeleteById<TDocument>(string documentId) where TDocument : ConfigurationDocument;
+        Task DeleteById<TDocument>(string documentId, CancellationToken cancellationToken) where TDocument : ConfigurationDocument;
 
-        Task CreateOrUpdate<TDocument>(string id, Action<TDocument> assignPropertiesCallback) where TDocument : ConfigurationDocument, new();
+        Task CreateOrUpdate<TDocument>(string id, Action<TDocument> assignPropertiesCallback, CancellationToken cancellationToken) where TDocument : ConfigurationDocument, new();
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IConfigurationStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IConfigurationStoreAsync.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Octopus.Data.Model.Configuration;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public interface IConfigurationStoreAsync
+    {
+        Task<TDocument?> Get<TDocument>(string id) where TDocument : ConfigurationDocument;
+
+        Task Create<TDocument>(TDocument document) where TDocument : ConfigurationDocument;
+
+        Task Update<TDocument>(TDocument document) where TDocument : ConfigurationDocument;
+
+        Task Delete<TDocument>(TDocument document) where TDocument : ConfigurationDocument;
+
+        Task DeleteById<TDocument>(string documentId) where TDocument : ConfigurationDocument;
+
+        Task CreateOrUpdate<TDocument>(string id, Action<TDocument> assignPropertiesCallback) where TDocument : ConfigurationDocument, new();
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IExtensionConfigurationStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IExtensionConfigurationStoreAsync.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public interface IExtensionConfigurationStoreAsync
+    {
+        Task<bool> GetIsEnabled();
+        Task SetIsEnabled(bool isEnabled);
+    }
+
+    public interface IExtensionConfigurationStoreAsync<TConfiguration> : IConfigurationDocumentStoreAsync<TConfiguration>,
+                                                                    IExtensionConfigurationStoreAsync
+        where TConfiguration : ExtensionConfigurationDocument, new()
+    {
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IExtensionConfigurationStoreAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IExtensionConfigurationStoreAsync.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
     public interface IExtensionConfigurationStoreAsync
     {
-        Task<bool> GetIsEnabled();
-        Task SetIsEnabled(bool isEnabled);
+        Task<bool> GetIsEnabled(CancellationToken cancellationToken);
+        Task SetIsEnabled(bool isEnabled, CancellationToken cancellationToken);
     }
 
     public interface IExtensionConfigurationStoreAsync<TConfiguration> : IConfigurationDocumentStoreAsync<TConfiguration>,

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasAggregatedConfigurationSettingsAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasAggregatedConfigurationSettingsAsync.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
     public interface IHasAggregatedConfigurationSettingsAsync : IHasConfigurationSettingsResourceAsync
     {
-        Task<object> GetConfigurationResource();
+        Task<object> GetConfigurationResource(CancellationToken cancellationToken);
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasAggregatedConfigurationSettingsAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasAggregatedConfigurationSettingsAsync.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public interface IHasAggregatedConfigurationSettingsAsync : IHasConfigurationSettingsResourceAsync
+    {
+        Task<object> GetConfigurationResource();
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsAsync.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+using Octopus.Server.Extensibility.Extensions.Mappings;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public interface IHasConfigurationSettingsAsync : IHasConfigurationSettingsResourceAsync, IContributeMappings
+    {
+        Task<object> GetConfiguration();
+
+        Task SetConfiguration(object config);
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsAsync.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Server.Extensibility.Extensions.Mappings;
 
@@ -6,8 +7,8 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
     public interface IHasConfigurationSettingsAsync : IHasConfigurationSettingsResourceAsync, IContributeMappings
     {
-        Task<object> GetConfiguration();
+        Task<object> GetConfiguration(CancellationToken cancellationToken);
 
-        Task SetConfiguration(object config);
+        Task SetConfiguration(object config, CancellationToken cancellationToken);
     }
 }

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsResourceAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsResourceAsync.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
+{
+    public interface IHasConfigurationSettingsResourceAsync
+    {
+        string Id { get; }
+
+        string ConfigurationSetName { get; }
+
+        string Description { get; }
+
+        Type MetadataResourceType { get; }
+
+        IAsyncEnumerable<IConfigurationValue> GetConfigurationValues();
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsResourceAsync.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/Configuration/IHasConfigurationSettingsResourceAsync.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 {
@@ -13,6 +14,6 @@ namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration
 
         Type MetadataResourceType { get; }
 
-        IAsyncEnumerable<IConfigurationValue> GetConfigurationValues();
+        IAsyncEnumerable<IConfigurationValue> GetConfigurationValues(CancellationToken cancellationToken = default);
     }
 }

--- a/source/Server.Extensibility/Extensions/Model/Environments/IContributeDeploymentEnvironmentSettingsMetadata.cs
+++ b/source/Server.Extensibility/Extensions/Model/Environments/IContributeDeploymentEnvironmentSettingsMetadata.cs
@@ -8,6 +8,6 @@ namespace Octopus.Server.Extensibility.Extensions.Model.Environments
     {
         string ExtensionId { get; }
         string ExtensionName { get; }
-        IAsyncEnumerable<PropertyMetadata> Properties { get; }
+        IAsyncEnumerable<PropertyMetadata> Properties();
     }
 }

--- a/source/Server.Extensibility/Extensions/Model/Environments/IContributeDeploymentEnvironmentSettingsMetadata.cs
+++ b/source/Server.Extensibility/Extensions/Model/Environments/IContributeDeploymentEnvironmentSettingsMetadata.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using Octopus.Server.Extensibility.Metadata;
 
 namespace Octopus.Server.Extensibility.Extensions.Model.Environments
@@ -8,6 +9,6 @@ namespace Octopus.Server.Extensibility.Extensions.Model.Environments
     {
         string ExtensionId { get; }
         string ExtensionName { get; }
-        IAsyncEnumerable<PropertyMetadata> Properties();
+        IAsyncEnumerable<PropertyMetadata> Properties(CancellationToken cancellationToken = default);
     }
 }

--- a/source/Server.Extensibility/Extensions/Model/Environments/IContributeDeploymentEnvironmentSettingsMetadata.cs
+++ b/source/Server.Extensibility/Extensions/Model/Environments/IContributeDeploymentEnvironmentSettingsMetadata.cs
@@ -8,7 +8,6 @@ namespace Octopus.Server.Extensibility.Extensions.Model.Environments
     {
         string ExtensionId { get; }
         string ExtensionName { get; }
-
-        List<PropertyMetadata> Properties { get; }
+        IAsyncEnumerable<PropertyMetadata> Properties { get; }
     }
 }

--- a/source/Server.Extensibility/Extensions/WorkItems/IIssueTracker.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IIssueTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.Extensions.WorkItems
@@ -13,7 +14,7 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         /// <summary>
         ///     Gets whether the issue tracker is currently enabled
         /// </summary>
-        Task<bool> IsEnabled();
+        Task<bool> IsEnabled(CancellationToken cancellationToken);
 
         /// <summary>
         ///     The CommentParser of this tracker, used by the build extensions to identify which baseUrl to prefix the linkUrl
@@ -24,6 +25,6 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         /// <summary>
         ///     The base Url to prefix the work item's linkUrl with.
         /// </summary>
-        Task<string?> BaseUrl();
+        Task<string?> BaseUrl(CancellationToken cancellationToken);
     }
 }

--- a/source/Server.Extensibility/Extensions/WorkItems/IIssueTracker.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IIssueTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.Extensions.WorkItems
 {
@@ -12,7 +13,7 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         /// <summary>
         ///     Gets whether the issue tracker is currently enabled
         /// </summary>
-        bool IsEnabled { get; }
+        Task<bool> IsEnabled();
 
         /// <summary>
         ///     The CommentParser of this tracker, used by the build extensions to identify which baseUrl to prefix the linkUrl
@@ -23,6 +24,6 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         /// <summary>
         ///     The base Url to prefix the work item's linkUrl with.
         /// </summary>
-        string? BaseUrl { get; }
+        Task<string?> BaseUrl();
     }
 }

--- a/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
@@ -9,7 +9,7 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
     public interface IWorkItemLinkMapper
     {
         string CommentParser { get; }
-        bool IsEnabled { get; }
+        Task<bool> IsEnabled { get; }
 
         Task<IResultFromExtension<WorkItemLink[]>> Map(OctopusBuildInformation buildInformation);
     }

--- a/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Server.Extensibility.Results;
 using Octopus.Server.MessageContracts.Features.BuildInformation;
@@ -9,7 +10,7 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
     public interface IWorkItemLinkMapper
     {
         string CommentParser { get; }
-        Task<bool> IsEnabled();
-        Task<IResultFromExtension<WorkItemLink[]>> Map(OctopusBuildInformation buildInformation);
+        Task<bool> IsEnabled(CancellationToken cancellationToken);
+        Task<IResultFromExtension<WorkItemLink[]>> Map(OctopusBuildInformation buildInformation, CancellationToken cancellationToken);
     }
 }

--- a/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Octopus.Server.Extensibility.Results;
 using Octopus.Server.MessageContracts.Features.BuildInformation;
 using Octopus.Server.MessageContracts.Features.IssueTrackers;
@@ -10,6 +11,6 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
         string CommentParser { get; }
         bool IsEnabled { get; }
 
-        IResultFromExtension<WorkItemLink[]> Map(OctopusBuildInformation buildInformation);
+        Task<IResultFromExtension<WorkItemLink[]>> Map(OctopusBuildInformation buildInformation);
     }
 }

--- a/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
+++ b/source/Server.Extensibility/Extensions/WorkItems/IWorkItemLinkMapper.cs
@@ -9,8 +9,7 @@ namespace Octopus.Server.Extensibility.Extensions.WorkItems
     public interface IWorkItemLinkMapper
     {
         string CommentParser { get; }
-        Task<bool> IsEnabled { get; }
-
+        Task<bool> IsEnabled();
         Task<IResultFromExtension<WorkItemLink[]>> Map(OctopusBuildInformation buildInformation);
     }
 }

--- a/source/Server.Extensibility/HostServices/Configuration/IServerConfigurationStore.cs
+++ b/source/Server.Extensibility/HostServices/Configuration/IServerConfigurationStore.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.HostServices.Configuration
 {
     public interface IServerConfigurationStore
     {
         string? GetServerUri();
+        Task<string?> GetServerUriAsync();
     }
 }

--- a/source/Server.Extensibility/HostServices/Configuration/IServerConfigurationStore.cs
+++ b/source/Server.Extensibility/HostServices/Configuration/IServerConfigurationStore.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.HostServices.Configuration
@@ -6,6 +7,6 @@ namespace Octopus.Server.Extensibility.HostServices.Configuration
     public interface IServerConfigurationStore
     {
         string? GetServerUri();
-        Task<string?> GetServerUriAsync();
+        Task<string?> GetServerUriAsync(CancellationToken cancellationToken);
     }
 }

--- a/source/Server.Extensibility/HostServices/Licensing/IInstallationIdProvider.cs
+++ b/source/Server.Extensibility/HostServices/Licensing/IInstallationIdProvider.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.HostServices.Licensing
 {
     public interface IInstallationIdProvider
     {
         Guid GetInstallationId();
+
+        Task<Guid> GetInstallationIdAsync();
     }
 }

--- a/source/Server.Extensibility/HostServices/Licensing/IInstallationIdProvider.cs
+++ b/source/Server.Extensibility/HostServices/Licensing/IInstallationIdProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Server.Extensibility.HostServices.Licensing
@@ -7,6 +8,6 @@ namespace Octopus.Server.Extensibility.HostServices.Licensing
     {
         Guid GetInstallationId();
 
-        Task<Guid> GetInstallationIdAsync();
+        Task<Guid> GetInstallationIdAsync(CancellationToken cancellationToken);
     }
 }

--- a/source/Server.Extensibility/Results/ResultFromExtension.cs
+++ b/source/Server.Extensibility/Results/ResultFromExtension.cs
@@ -39,7 +39,7 @@ namespace Octopus.Server.Extensibility.Results
 
         public static IFailureResultFromExtension Failed()
         {
-            return new FailureResultFromExtension(new string[0]);
+            return new FailureResultFromExtension(Array.Empty<string>());
         }
 
         public new static IFailureResultFromExtension Failed(params string[] errors)
@@ -76,7 +76,7 @@ namespace Octopus.Server.Extensibility.Results
 
         public static IFailureResultFromExtension<T> Failed()
         {
-            return new FailureResultFromExtension<T>(new string[0]);
+            return new FailureResultFromExtension<T>(Array.Empty<string>());
         }
 
         public new static IFailureResultFromExtension<T> Failed(params string[] errors)

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -37,7 +37,4 @@
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Diagnostics" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
WorkItems link mapper is now async, all consumers of this interface are doing network calls, hence the need for async here.

So I started with `IWorkItemLinkMapper` but once I pulled on that thread I ended up doing quite a few extra areas async as well.

Areas that I converted to be async:
- Configuration retrieval and setters
- As mentioned above the work items mappings
- Infrastructure settings like `IServerConfigurationStore` and `IInstallationIdProvider`, these I opted to have both sync and async, given the amount of work involved in covering all the areas in Server
- Also `IContributeDeploymentEnvironmentSettingsMetadata`