### PR TITLE
Move collectors interfaces to extensions

### DIFF
--- a/source/Server.Extensibility/Extensions/Infrastructure/TelemetryCollectors/ISpaceTelemetryCollectionCollector.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/TelemetryCollectors/ISpaceTelemetryCollectionCollector.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Server.MessageContracts.Features.Spaces;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.TelemetryCollectors
+{
+    public interface ISpaceTelemetryCollectionCollector
+    {
+        Task<Dictionary<string, object>> CollectForSpace(SpaceId spaceId, CancellationToken cancellationToken);
+        Task<Dictionary<string, object>> CollectForAllSpaces(CancellationToken cancellationToken);
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/TelemetryCollectors/ISpaceTelemetryCollector.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/TelemetryCollectors/ISpaceTelemetryCollector.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Server.MessageContracts.Features.Spaces;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.TelemetryCollectors
+{
+    public interface ISpaceTelemetryCollector
+    {
+        Task<KeyValuePair<string, object>> CollectForSpace(SpaceId spaceId, CancellationToken cancellationToken);
+        Task<KeyValuePair<string, object>> CollectForAllSpaces(CancellationToken cancellationToken);
+    }
+}

--- a/source/Server.Extensibility/Extensions/Infrastructure/TelemetryCollectors/ISystemTelemetryCollector.cs
+++ b/source/Server.Extensibility/Extensions/Infrastructure/TelemetryCollectors/ISystemTelemetryCollector.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.TelemetryCollectors
+{
+    public interface ISystemTelemetryCollector
+    {
+        Task<KeyValuePair<string, object>> Collect(CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
The interfaces were introduced as part of https://github.com/OctopusDeploy/OctopusDeploy/pull/10215

From an extensibility side, we also want to be able to contribute telemetry, hence this move.
