### PR TITLE
Support separation between base message interfaces and concrete message types.

### DIFF
--- a/source/Server.Extensibility/Mediator/IHandleBroadcastRequest.cs
+++ b/source/Server.Extensibility/Mediator/IHandleBroadcastRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
-using Octopus.Server.MessageContracts;
+using Octopus.Server.MessageContracts.Base;
 
 namespace Octopus.Server.Extensibility.Mediator
 {

--- a/source/Server.Extensibility/Mediator/IHandleCommand.cs
+++ b/source/Server.Extensibility/Mediator/IHandleCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Octopus.Server.MessageContracts;
+using Octopus.Server.MessageContracts.Base;
 
 namespace Octopus.Server.Extensibility.Mediator
 {

--- a/source/Server.Extensibility/Mediator/IHandleRequest.cs
+++ b/source/Server.Extensibility/Mediator/IHandleRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Octopus.Server.MessageContracts;
+using Octopus.Server.MessageContracts.Base;
 
 namespace Octopus.Server.Extensibility.Mediator
 {

--- a/source/Server.Extensibility/Mediator/IMediator.cs
+++ b/source/Server.Extensibility/Mediator/IMediator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Server.MessageContracts;
+using Octopus.Server.MessageContracts.Base;
 
 namespace Octopus.Server.Extensibility.Mediator
 {

--- a/source/Server.Extensibility/Server.Extensibility.csproj
+++ b/source/Server.Extensibility/Server.Extensibility.csproj
@@ -30,8 +30,10 @@
     <PackageReference Include="Octopus.Data" Version="7.1.5" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.2" />
     <PackageReference Include="Octopus.Ocl" Version="0.4.843" />
-    <PackageReference Include="Octopus.Server.MessageContracts" Version="0.5.100" />
-    <PackageReference Include="Octopus.TinyTypes" Version="2.2.26" />
+    <PackageReference Include="Octopus.Server.MessageContracts.Base" Version="3.0.251" />
+    <PackageReference Include="Octopus.Server.MessageContracts.Base.HttpRoutes" Version="3.0.251" />
+    <PackageReference Include="Octopus.Server.MessageContracts" Version="3.0.251" />
+    <PackageReference Include="Octopus.TinyTypes" Version="2.2.118" />
     <PackageReference Include="Octopus.Versioning" Version="5.1.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />


### PR DESCRIPTION
Bump Octopus.Server.MessageContracts and friends to support separation between base message interfaces and concrete message types.