### PR TITLE
Limit the number of concurrent Dependabot-generated pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/source/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "Autofac*"
       - dependency-name: "Octopus*"


### PR DESCRIPTION
We want to be confident that Dependabot-generated changes, although potentially individually green, don't conflict with each other. By limiting the number of open PRs to one, we can guarantee that each PR will already incorporate all the changes of the other PRs.