### PR TITLE
Feed Package to Octopus Deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,29 @@ jobs:
         shell: bash
         run: ./build.sh --verbosity verbose
 
-      - name: Push package to feed 🐙
-        id: push-feed
-        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && github.event_name != 'schedule'
-        shell: bash
-        env:
-          FEED_API_KEY: ${{ secrets.FEED_API_KEY }}
-          FEED_SOURCE: ${{ secrets.FEED_SOURCE }}
-        run: dotnet nuget push artifacts/**/*.nupkg --api-key "$FEED_API_KEY" --source "$FEED_SOURCE"
+      - name: Install Octopus CLI 🐙
+        uses: OctopusDeploy/install-octopus-cli-action@v1
+        with:
+          version: latest
+        
+      - name: Push to Octopus 🐙
+        uses: OctopusDeploy/push-package-action@v1
+        with:
+          server: ${{ secrets.DEPLOY_URL }}
+          space: Core Platform
+          api_key: ${{ secrets.DEPLOY_API_KEY }}
+          packages: |
+            ./artifacts/Octopus.Server.Extensibility.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg          
+
+      - name: Create Release in Octopus 🐙
+        uses: OctopusDeploy/create-release-action@v1
+        with:
+          server: ${{ secrets.DEPLOY_URL }}
+          space: Core Platform
+          api_key: ${{ secrets.DEPLOY_API_KEY }}
+          project: "ServerExtensibility"
+          packages: |
+            Octopus.Server.Extensibility:${{ steps.build.outputs.octoversion_fullsemver }}
         
       - name: GitHub Tag 🏷
         id: github-tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,16 +59,15 @@ jobs:
           packages: |
             Octopus.Server.Extensibility:${{ steps.build.outputs.octoversion_fullsemver }}
         
-      - name: GitHub Tag 🏷
-        id: github-tag
+      - name: Tag release (when not pre-release) 🏷️
+        if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}
         uses: actions/github-script@v3
-        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && github.event_name != 'schedule' && steps.build.outputs.prerelease_tag == ''
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             github.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: "refs/tags/${{ steps.build.outputs.semver }}",
+              ref: "refs/tags/${{ steps.build.outputs.octoversion_fullsemver }}",
               sha: context.sha
             })

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -6,6 +6,10 @@
     "build": {
       "type": "object",
       "properties": {
+        "AutoDetectBranch": {
+          "type": "boolean",
+          "description": "Whether to auto-detect the branch name - this is okay for a local build, but should not be used under CI"
+        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -21,6 +25,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",
@@ -37,6 +42,10 @@
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
+        },
+        "OCTOVERSION_CurrentBranch": {
+          "type": "string",
+          "description": "Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable OCTOVERSION_CurrentBranch"
         },
         "Partition": {
           "type": "string",
@@ -66,9 +75,6 @@
               "CalculateVersion",
               "Clean",
               "Compile",
-              "CopyToLocalPackages",
-              "Default",
-              "OutputPackagesToPush",
               "Pack",
               "Restore",
               "Test"
@@ -88,9 +94,6 @@
               "CalculateVersion",
               "Clean",
               "Compile",
-              "CopyToLocalPackages",
-              "Default",
-              "OutputPackagesToPush",
               "Pack",
               "Restore",
               "Test"

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageDownload Include="OctoVersion.Tool" Version="[0.3.49]" />
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+    <PackageReference Include="Nuke.Common" Version="6.1.2" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.300",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
For consistency, package feed is now pushed to Octopus.
Updated to `Nuke 6`
Aligning build steps to use `octoversion`